### PR TITLE
Hard-code network_device property to cpu for GymNE

### DIFF
--- a/src/evotorch/neuroevolution/gymne.py
+++ b/src/evotorch/neuroevolution/gymne.py
@@ -239,6 +239,14 @@ class GymNE(NEProblem):
         super()._prepare()
         self._get_env()
 
+    @property
+    def network_device(self) -> Device:
+        """The device on which the problem should place data e.g. the network
+        In the case of GymNE, supported Gym environments return numpy arrays on CPU which are converted to Tensors
+        Therefore, it is almost always optimal to place the network on CPU
+        """
+        return torch.device("cpu")
+
     def _rollout(
         self,
         *,


### PR DESCRIPTION
Currently there are scenarios where the user can have the `network_device` property return some form of `torch.device('cuda:x')` when using the `evotorch.neuroevolution.GymNE` neuroevolution class.

This class is not designed to support Policy networks on the GPU, as the environments' observations are returned as numpy arrays which are then cast to torch tensors on the CPU. This then causes a bug (for example: see #4 ) where the user is unable to run simple GymNE experiments. 

In future releases, we should consider the possibility that the user may want the Policy network on the GPU -- especially if we look to supporting other (GPU-based) environments. However, in the short term, there is no mechanism for observations even being placed on a non-cpu device. This pull-request therefore offers a transparent short-term fix that complies with our current expectation of `GymNE`'s usage:

- The `network_device` property of `GymNE` is hard-coded to return `torch.device('cpu')`. This ensures that the Policy network is *always* on the CPU and therefore resolves bugs such as those experienced in #4 . 
