### PR TITLE
Bugfix for str_to_net(...)

### DIFF
--- a/src/evotorch/neuroevolution/net/parser.py
+++ b/src/evotorch/neuroevolution/net/parser.py
@@ -86,7 +86,7 @@ class NetParsingError(Exception):
 
 def submodules(a: nn.Module) -> list:
     if isinstance(a, nn.Sequential):
-        return [module for i, module in enumerate(a.modules()) if i >= 1]
+        return [module for module in a]
     else:
         return [a]
 


### PR DESCRIPTION
When extracting the child modules of an `nn.Sequential` instance, the parser used by `str_to_net(...)` was traversing in a recursive manner (which is undesired). The newly proposed code here uses the iterable nature of `nn.Sequential` to correctly extract the child modules of `nn.Sequential`.

When working with modules which are composed of other modules, `str_to_net(...)` was erroneously adding the children modules twice into the resulting `nn.Sequential`. For example, when the network string contains `RecurrentNet` (`RecurrentNet` being a module that wraps a child `RNN` module) the resulting `nn.Sequential` was ending up with the `RecurrentNet` _and_ its child `RNN` appended erroneously. This proposal aims to fix this issue.