### PR TITLE
Add documentation of NeptuneLogger class 

### DIFF
--- a/docs/user_guide/logging.md
+++ b/docs/user_guide/logging.md
@@ -97,7 +97,7 @@ plt.show()
 
 ## Remote Logging with `mlflow`
 
-There is also a logger class named [MlFlowLogger][evotorch.logging.MlFlowLogger] which logs the metrics via the `mlflow` library.
+There is also a logger class named [MlflowLogger][evotorch.logging.MlflowLogger] which logs the metrics via the `mlflow` library.
 With the help of `mlflow`, the logs can be stored into the local disk or into a remote server.
 
 In the simplest case, a script which stores its logs with the help of `mlflow` looks like this:

--- a/docs/user_guide/logging.md
+++ b/docs/user_guide/logging.md
@@ -181,7 +181,7 @@ def main():
 
 ## Remote Logging with `neptune`
 
-EvoTorch also supports remote logging with [Neptune](neptune.ai). To use this functionality, you must have the `neptune-client` package installed. Then usage of [NeptuneLogger][evotorch.logging.NeptuneLogger] is as simple as creating a `neptune.new.run.Run` instance and passing it to the logger class at instantiation. 
+EvoTorch also supports remote logging with [Neptune](https://neptune.ai/home). To use this functionality, you must have the `neptune-client` package installed. Then usage of [NeptuneLogger][evotorch.logging.NeptuneLogger] is as simple as creating a `neptune.new.run.Run` instance and passing it to the logger class at instantiation.
 
 ```python
 from evotorch import Problem
@@ -199,8 +199,8 @@ searcher = SNES(problem, ...)
 import neptune.new as neptune
 
 run = neptune.init(
-    project = 'workspace-name/project-name',
-) # Start an neptune run to log to
+    project='workspace-name/project-name',
+)  # Start an neptune run to log to
 _ = NeptuneLogger(searcher, run=run)
 
 # Run the search algorithm

--- a/docs/user_guide/logging.md
+++ b/docs/user_guide/logging.md
@@ -105,7 +105,7 @@ In the simplest case, a script which stores its logs with the help of `mlflow` l
 ```python
 from evotorch import Problem
 from evotorch.algorithms import SNES
-from evotorch.logging import StdOutLogger, MlFlowLogger
+from evotorch.logging import StdOutLogger, MlflowLogger
 
 # Somehow instantiate the problem
 problem = Problem(...)

--- a/docs/user_guide/logging.md
+++ b/docs/user_guide/logging.md
@@ -105,7 +105,7 @@ In the simplest case, a script which stores its logs with the help of `mlflow` l
 ```python
 from evotorch import Problem
 from evotorch.algorithms import SNES
-from evotorch.logginer import StdOutLogger, MlFlowLoger
+from evotorch.logging import StdOutLogger, MlFlowLoger
 
 # Somehow instantiate the problem
 problem = Problem(...)
@@ -139,7 +139,7 @@ The basic structure of a script using `sacred` is as follows:
 ```python
 from evotorch import Problem
 from evotorch.algorithms import SNES
-from evotorch.logginer import StdOutLogger, SacredLogger
+from evotorch.logging import StdOutLogger, SacredLogger
 
 from sacred import Experiment
 from evotorch.tools import SuppressSacredExperiment
@@ -177,4 +177,35 @@ def main():
 
     # Run the search algorithm
     searcher.run(100)
+```
+
+## Remote Logging with `neptune`
+
+EvoTorch also supports remote logging with [Neptune](neptune.ai). To use this functionality, you must have the `neptune-client` package installed. Then usage of `NeptuneLogger` is as simple as creating a `neptune.new.run.Run` instance and passing it to `NeptuneLogger` at instantiation. 
+
+```python
+from evotorch import Problem
+from evotorch.algorithms import SNES
+from evotorch.logging import NeptuneLogger
+
+# Somehow instantiate the problem
+problem = Problem(...)
+
+# Somehow instantiate the search algorithm
+searcher = SNES(problem, ...)
+
+# In addition, instantiate an NeptuneLogger so that the logs are stored
+# via neptune.
+import neptune.new as neptune
+
+run = neptune.init(
+    project = 'workspace-name/project-name',
+) # Start an neptune run to log to
+_ = NeptuneLogger(searcher, run=run)
+
+# Run the search algorithm
+searcher.run(100)
+
+# Stop the neptune run
+run.stop()
 ```

--- a/docs/user_guide/logging.md
+++ b/docs/user_guide/logging.md
@@ -97,7 +97,7 @@ plt.show()
 
 ## Remote Logging with `mlflow`
 
-There is also a logger class named `MlflowLogger` which logs the metrics via the `mlflow` library.
+There is also a logger class named [MlFlowLogger][evotorch.logging.MlFlowLogger] which logs the metrics via the `mlflow` library.
 With the help of `mlflow`, the logs can be stored into the local disk or into a remote server.
 
 In the simplest case, a script which stores its logs with the help of `mlflow` looks like this:
@@ -105,7 +105,7 @@ In the simplest case, a script which stores its logs with the help of `mlflow` l
 ```python
 from evotorch import Problem
 from evotorch.algorithms import SNES
-from evotorch.logging import StdOutLogger, MlFlowLoger
+from evotorch.logging import StdOutLogger, MlFlowLogger
 
 # Somehow instantiate the problem
 problem = Problem(...)
@@ -133,7 +133,7 @@ searcher.run(100)
 
 ## Remote Logging with `sacred`
 
-As an alternative to `mlflow`, one might want to log the metrics with the help of the `sacred` library.
+As an alternative to `mlflow`, one might want to log the metrics with the help of the `sacred` library using the [SacredLogger][evotorch.logging.SacredLogger] class.
 The basic structure of a script using `sacred` is as follows:
 
 ```python
@@ -181,7 +181,7 @@ def main():
 
 ## Remote Logging with `neptune`
 
-EvoTorch also supports remote logging with [Neptune](neptune.ai). To use this functionality, you must have the `neptune-client` package installed. Then usage of `NeptuneLogger` is as simple as creating a `neptune.new.run.Run` instance and passing it to `NeptuneLogger` at instantiation. 
+EvoTorch also supports remote logging with [Neptune](neptune.ai). To use this functionality, you must have the `neptune-client` package installed. Then usage of [NeptuneLogger][evotorch.logging.NeptuneLogger] is as simple as creating a `neptune.new.run.Run` instance and passing it to the logger class at instantiation. 
 
 ```python
 from evotorch import Problem


### PR DESCRIPTION
Closes #8 

Currently, `evotorch.logging.NeptuneLogger` is undocumented in the user guide, as described in #8 . This pull request resolves this issue by adding an additional section of documentation to `userguide/logging` in the documentation. 