### PR TITLE
Cloning and serialization improvements

### DIFF
--- a/src/evotorch/distributions.py
+++ b/src/evotorch/distributions.py
@@ -22,11 +22,12 @@ from .tools import Device, DType, cast_tensors_in_container, device_of_container
 from .tools import multiply_rows_by_scalars as dot
 from .tools import rowwise_sum as total
 from .tools import to_torch_dtype
+from .tools.cloning import Serializable, deep_clone
 from .tools.ranking import rank
 from .tools.tensormaker import TensorMakerMixin
 
 
-class Distribution(TensorMakerMixin):
+class Distribution(TensorMakerMixin, Serializable):
     """
     Base class for any search distribution.
     """
@@ -385,6 +386,14 @@ class Distribution(TensorMakerMixin):
         if optimizers is None:
             optimizers = {}
         return learning_rates.get(param_name, None), optimizers.get(param_name, None)
+
+    @torch.no_grad()
+    def _get_cloned_state(self, *, memo: dict) -> dict:
+        return deep_clone(
+            self.__dict__,
+            otherwise_deepcopy=True,
+            memo=memo,
+        )
 
 
 class SeparableGaussian(Distribution):

--- a/src/evotorch/tools/__init__.py
+++ b/src/evotorch/tools/__init__.py
@@ -18,9 +18,11 @@ This namespace contains various utility functions, classes, and type aliases.
 
 
 __all__ = (
+    "cloning",
     "Hook",
     "as_immutable",
     "mutable_copy",
+    "recursiveprintable",
     "Device",
     "DType",
     "DTypeAndDevice",
@@ -80,7 +82,7 @@ __all__ = (
 )
 
 
-from . import hook, immutable, objectarray, ranking, readonlytensor, tensormaker
+from . import cloning, hook, immutable, objectarray, ranking, readonlytensor, recursiveprintable, tensormaker
 from .hook import Hook
 from .immutable import as_immutable, mutable_copy
 from .misc import (

--- a/src/evotorch/tools/cloning.py
+++ b/src/evotorch/tools/cloning.py
@@ -1,0 +1,339 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import OrderedDict
+from copy import deepcopy
+from numbers import Number
+from typing import Any, Optional
+
+import numpy as np
+import torch
+
+
+def deep_clone(  # noqa: C901
+    x: Any,
+    *,
+    otherwise_deepcopy: bool = False,
+    otherwise_return: bool = False,
+    otherwise_fail: bool = False,
+    memo: Optional[dict] = None,
+) -> Any:
+    """
+    A recursive cloning function similar to the standard `deepcopy`.
+
+    The difference between `deep_clone(...)` and `deepcopy(...)` is that
+    `deep_clone(...)`, while recursively traversing, will run the `.clone()`
+    method on the PyTorch tensors it encounters, so that the cloned tensors
+    are forcefully detached from their storages (instead of cloning those
+    storages as well).
+
+    At the moment of writing this documentation, the current behavior of
+    PyTorch tensors upon being deep-copied is to clone themselves AND their
+    storages. Therefore, if a PyTorch tensor is a slice of a large tensor
+    (which has a large storage), then the large storage will also be
+    deep-copied, and the newly made clone of the tensor will point to a newly
+    made large storage. One might instead prefer to clone tensors in such a
+    way that the newly made tensor points to a newly made storage that
+    contains just enough data for the tensor (with the unused data being
+    dropped). When such a behavior is desired, one can use this
+    `deep_clone(...)` function.
+
+    Upon encountering a read-only and/or immutable data, this function will
+    NOT modify the read-only behavior. For example, the deep-clone of a
+    ReadOnlyTensor is still a ReadOnlyTensor, and the deep-clone of a
+    read-only numpy array is still a read-only numpy array. Note that this
+    behavior is different than the `clone()` method of a ReadOnlyTensor
+    and the `copy()` method of a numpy array. The reason for this
+    protective behavior is that since this is a deep-cloning operation,
+    the encountered tensors and/or arrays might be the components of the root
+    object, and changing their read-only attributes might affect the integrity
+    of this root object.
+
+    The `deep_clone(...)` function needs to know what to do when an object
+    of unrecognized type is encountered. Therefore, the user is expected to
+    set one of these arguments as True (and leave the others as False):
+    `otherwise_deepcopy`, `otherwise_return`, `otherwise_fail`.
+
+    Args:
+        x: The object which will be deep-cloned. This object can be a standard
+            Python container (i.e. list, tuple, dict, set), an instance of
+            Problem, Solution, SolutionBatch, ObjectArray, ImmutableContainer,
+            Clonable, and also any other type of object if either the argument
+            `otherwise_deepcopy` or the argument `otherwise_return` is set as
+            True.
+        otherwise_deepcopy: Setting this as True means that, when an
+            unrecognized object is encountered, that object will be
+            deep-copied. To handle shared and cyclic-referencing objects,
+            the `deep_clone(...)` function stores its own memo dictionary.
+            When the control is given to the standard `deepcopy(...)`
+            function, the memo dictionary of `deep_clone(...)` will be passed
+            to `deepcopy`.
+        otherwise_return: Setting this as True means that, when an
+            unrecognized object is encountered, that object itself will be
+            returned (i.e. will be a part of the created clone).
+        otherwise_fail: Setting this as True means that, when an unrecognized
+            object is encountered, a TypeError will be raised.
+        memo: Optionally a dictionary. In most scenarios, when this function
+            is called from outside, this is expected to be left as None.
+    Returns:
+        The newly made clone of the original object.
+    """
+    from .objectarray import ObjectArray
+    from .readonlytensor import ReadOnlyTensor
+
+    if memo is None:
+        # If a memo dictionary was not given, make a new one now.
+        memo = {}
+
+    # Get the id of the object being cloned.
+    x_id = id(x)
+
+    if x_id in memo:
+        # If the id of the object being cloned is already in the memo dictionary, then this object was previously
+        # cloned. We just return that clone.
+        return memo[x_id]
+
+    # Count how many of the arguments `otherwise_deepcopy`, `otherwise_return`, and `otherwise_fail` was set as True.
+    # In this context, we call these arguments as fallback behaviors.
+    fallback_behaviors = (otherwise_deepcopy, otherwise_return, otherwise_fail)
+    enabled_behavior_count = sum(1 for behavior in fallback_behaviors if behavior)
+
+    if enabled_behavior_count == 0:
+        # If none of the fallback behaviors was enabled, then we raise an error.
+        raise ValueError(
+            "The action to take with objects of unrecognized types is not known because"
+            " none of these arguments was set as True: `otherwise_deepcopy`, `otherwise_return`, `otherwise_fail`."
+            " Please set one of these arguments as True."
+        )
+    elif enabled_behavior_count == 1:
+        # If one of the fallback behaviors was enabled, then we received our expected input. We do nothing here.
+        pass
+    else:
+        # If the number of enabled fallback behaviors is an unexpected value. then we raise an error.
+        raise ValueError(
+            f"The following arguments were received, which is conflicting: otherwise_deepcopy={otherwise_deepcopy},"
+            f" otherwise_return={otherwise_return}, otherwise_fail={otherwise_fail}."
+            f" Please set exactly one of these arguments as True and leave the others as False."
+        )
+
+    # This inner function specifies how the deep_clone function should call itself.
+    def call_self(obj: Any) -> Any:
+        return deep_clone(
+            obj,
+            otherwise_deepcopy=otherwise_deepcopy,
+            otherwise_return=otherwise_return,
+            otherwise_fail=otherwise_fail,
+            memo=memo,
+        )
+
+    # Below, we handle the cloning behaviors case by case.
+    if (x is None) or (x is NotImplemented) or (x is Ellipsis):
+        result = deepcopy(x)
+    elif isinstance(x, (Number, str, bytes, bytearray)):
+        result = deepcopy(x, memo=memo)
+    elif isinstance(x, np.ndarray):
+        result = x.copy()
+        result.flags["WRITEABLE"] = x.flags["WRITEABLE"]
+    elif isinstance(x, (ObjectArray, ReadOnlyClonable)):
+        result = x.clone(preserve_read_only=True, memo=memo)
+    elif isinstance(x, ReadOnlyTensor):
+        result = x.clone(preserve_read_only=True)
+    elif isinstance(x, torch.Tensor):
+        result = x.clone()
+    elif isinstance(x, Clonable):
+        result = x.clone(memo=memo)
+    elif isinstance(x, (dict, OrderedDict)):
+        result = type(x)()
+        memo[x_id] = result
+        for k, v in x.items():
+            result[call_self(k)] = call_self(v)
+    elif isinstance(x, list):
+        result = type(x)()
+        memo[x_id] = result
+        for item in x:
+            result.append(call_self(item))
+    elif isinstance(x, set):
+        result = type(x)()
+        memo[x_id] = result
+        for item in x:
+            result.add(call_self(item))
+    elif isinstance(x, tuple):
+        result = []
+        memo[x_id] = result
+        for item in x:
+            result.append(call_self(item))
+        if hasattr(x, "_fields"):
+            result = type(x)(*result)
+        else:
+            result = type(x)(result)
+        memo[x_id] = result
+    else:
+        # If the object is not recognized, we use the fallback behavior.
+        if otherwise_deepcopy:
+            result = deepcopy(x, memo=memo)
+        elif otherwise_return:
+            result = x
+        elif otherwise_fail:
+            raise TypeError(f"Do not know how to clone {repr(x)} (of type {type(x)}).")
+        else:
+            raise RuntimeError("The function `deep_clone` reached an unexpected state. This might be a bug.")
+
+    if (x_id not in memo) and (result is not x):
+        # If the newly made clone is still not in the memo dictionary AND the "clone" is not just a reference to the
+        # original object, we make sure that it is in the memo dictionary.
+        memo[x_id] = result
+
+    # Finally, the result is returned.
+    return result
+
+
+class Clonable:
+    """
+    A base class allowing inheriting classes define how they should be cloned.
+
+    Any class inheriting from Clonable gains these behaviors:
+    (i) A new method named `.clone()` becomes available;
+    (ii) `__deepcopy__` and `__copy__` work as aliases for `.clone()`;
+    (iii) A new method, `_get_cloned_state(self, *, memo: dict)` is now
+    defined and needs to be implemented by the inheriting class.
+
+    The method `_get_cloned_state(...)` expects a dictionary named `memo`,
+    which maps from the ids of already cloned objects to their clones.
+    If `_get_cloned_state(...)` is to use `deep_clone(...)` or `deepcopy(...)`
+    within itself, this `memo` dictionary can be passed to these functions.
+    The return value of `_get_cloned_state(...)` is a dictionary, which will
+    be used as the `__dict__` of the newly made clone.
+    """
+
+    def _get_cloned_state(self, *, memo: dict) -> dict:
+        raise NotImplementedError
+
+    def clone(self, *, memo: Optional[dict] = None) -> "Clonable":
+        """
+        Get a clone of this object.
+
+        Args:
+            memo: Optionally a dictionary which maps from the ids of the
+                already cloned objects to their clones. In most scenarios,
+                when this method is called from outside, this can be left
+                as None.
+        Returns:
+            The clone of the object.
+        """
+        if memo is None:
+            memo = {}
+
+        self_id = id(self)
+        if self_id in memo:
+            return memo[self_id]
+
+        new_object = object.__new__(type(self))
+        memo[id(self)] = new_object
+
+        new_object.__dict__.update(self._get_cloned_state(memo=memo))
+        return new_object
+
+    def __copy__(self) -> "Clonable":
+        return self.clone()
+
+    def __deepcopy__(self, memo: Optional[dict]):
+        if memo is None:
+            memo = {}
+        return self.clone(memo=memo)
+
+
+class Serializable(Clonable):
+    """
+    Base class allowing the inheriting classes become Clonable and picklable.
+
+    Any class inheriting from `Serializable` becomes `Clonable` (since
+    `Serializable` is a subclass of `Clonable`) and therefore is expected to
+    define its own `_get_cloned_state(...)` (see the documentation of the
+    class `Clonable` for details).
+
+    A `Serializable` class gains a behavior for its `__getstate__`. In this
+    already defined and implemented `__getstate__` method, the resulting
+    dictionary of `_get_cloned_state(...)` is used as the state dictionary.
+    Therefore, for `Serializable` objects, the behavior defined in their
+    `_get_cloned_state(...)` methods affect how they are pickled.
+
+    Classes inheriting from `Serializable` are `evotorch.Problem`,
+    `evotorch.Solution`, `evotorch.SolutionBatch`, and
+    `evotorch.distributions.Distribution`. In their `_get_cloned_state(...)`
+    implementations, these classes use `deep_clone(...)` on themselves to make
+    sure that their contained PyTorch tensors are copied using the `.clone()`
+    method, ensuring that those tensors are detached from their old storages
+    during the cloning operation. Thanks to being `Serializable`, their
+    contained tensors are detached from their old storages both at the moment
+    of copying/cloning AND at the moment of pickling.
+    """
+
+    def __getstate__(self) -> dict:
+        memo = {id(self): self}
+        return self._get_cloned_state(memo=memo)
+
+
+class ReadOnlyClonable(Clonable):
+    """
+    Clonability base class for read-only and/or immutable objects.
+
+    This is a base class specialized for the immutable containers of EvoTorch.
+    These immutable containers have two behaviors for cloning:
+    one where the read-only attribute is preserved and one where a mutable
+    clone is created.
+
+    Upon being copied or deep-copied (using the standard Python functions),
+    the newly made clones are also read-only. However, when copied using the
+    `clone(...)` method, the newly made clone is mutable by default
+    (unless the `clone(...)` method was used with `preserve_read_only=True`).
+    This default behavior of the `clone(...)` method was inspired by the
+    `copy()` method of numpy arrays (the inspiration being that the `.copy()`
+    of a read-only numpy array will not be read-only anymore).
+
+    Subclasses of `evotorch.immutable.ImmutableContainer` inherit from
+    `ReadOnlyClonable`.
+    """
+
+    def _get_mutable_clone(self, *, memo: dict) -> Any:
+        raise NotImplementedError
+
+    def clone(self, *, memo: Optional[dict] = None, preserve_read_only: bool = False) -> Any:
+        """
+        Get a clone of this read-only object.
+
+        Args:
+            memo: Optionally a dictionary which maps from the ids of the
+                already cloned objects to their clones. In most scenarios,
+                when this method is called from outside, this can be left
+                as None.
+            preserve_read_only: Whether or not to preserve the read-only
+                behavior in the clone.
+        Returns:
+            The clone of the object.
+        """
+        if memo is None:
+            memo = {}
+        if preserve_read_only:
+            return super().clone(memo=memo)
+        else:
+            return self._get_mutable_clone(memo=memo)
+
+    def __copy__(self) -> Any:
+        return self.clone(preserve_read_only=True)
+
+    def __deepcopy__(self, memo: Optional[dict]) -> Any:
+        if memo is None:
+            memo = {}
+        return self.clone(memo=memo, preserve_read_only=True)

--- a/src/evotorch/tools/recursiveprintable.py
+++ b/src/evotorch/tools/recursiveprintable.py
@@ -1,0 +1,79 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any, Iterable, Mapping
+
+
+class RecursivePrintable:
+    """
+    A base class for making a class printable.
+
+    This base class considers custom container types which can recursively
+    contain themselves (even in a cyclic manner). Classes inheriting from
+    `RecursivePrintable` will gain a new ready-to-use method named
+    `to_string(...)`. This `to_string(...)` method, upon being called,
+    checks if the current class is an Iterable or a Mapping, and prints
+    the representation accordingly, with a recursion limit to avoid
+    `RecursionError`. The methods `__str__(...)` and `__repr__(...)`
+    are also defined as aliases of this `to_string` method.
+    """
+
+    def to_string(self, *, max_depth: int = 10) -> str:
+        if max_depth <= 0:
+            return "<...>"
+
+        def item_repr(x: Any) -> str:
+            if isinstance(x, RecursivePrintable):
+                return x.to_string(max_depth=(max_depth - 1))
+            else:
+                return repr(x)
+
+        result = []
+
+        def puts(*x: Any):
+            for item_of_x in x:
+                result.append(str(item_of_x))
+
+        clsname = type(self).__name__
+        first_one = True
+
+        if isinstance(self, Mapping):
+            puts(clsname, "({")
+            for k, v in self.items():
+                if first_one:
+                    first_one = False
+                else:
+                    puts(", ")
+                puts(item_repr(k), ": ", item_repr(v))
+            puts("})")
+        elif isinstance(self, Iterable):
+            puts(clsname, "([")
+            for v in self:
+                if first_one:
+                    first_one = False
+                else:
+                    puts(", ")
+                puts(item_repr(v))
+            puts("])")
+        else:
+            raise NotImplementedError
+
+        return "".join(result)
+
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def __repr__(self) -> str:
+        return self.to_string()

--- a/tests/test_cloning.py
+++ b/tests/test_cloning.py
@@ -1,0 +1,398 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import itertools
+import pickle
+from collections import namedtuple
+from copy import copy, deepcopy
+
+import numpy as np
+import pytest
+import torch
+
+from evotorch import Problem
+from evotorch.distributions import ExpGaussian, ExpSeparableGaussian, SeparableGaussian, SymmetricSeparableGaussian
+from evotorch.testing import assert_allclose, assert_eachclose
+from evotorch.tools import ObjectArray, ReadOnlyTensor, make_tensor
+from evotorch.tools.cloning import deep_clone
+from evotorch.tools.immutable import ImmutableDict, ImmutableList
+
+
+def test_deep_cloning():
+    tolerance = 1e-4
+
+    x = torch.randn(1000, 10)
+    y = x[2:5]
+    a = x[2:5]
+    b = x[12:15]
+
+    data = (y, {"a": a, "b": b})
+
+    clone_of_data = deep_clone(data, otherwise_fail=True)
+    clone_of_y = clone_of_data[0]
+    clone_of_a = clone_of_data[1]["a"]
+    clone_of_b = clone_of_data[1]["b"]
+
+    assert_allclose(clone_of_y, y, atol=tolerance)
+    assert_allclose(clone_of_a, a, atol=tolerance)
+    assert_allclose(clone_of_b, b, atol=tolerance)
+
+    # The deep-clone operation detaches the tensors from their original storages.
+    # Therefore, unlike their originals y and a, clone_of_y and clone_of_a should NOT share storage.
+    clone_of_y[:] = -1
+    clone_of_a[:] = 1
+
+    assert_eachclose(clone_of_y, -1, atol=tolerance)
+    assert_eachclose(clone_of_a, 1, atol=tolerance)
+
+
+def test_objectarray_cloning():
+    tolerance = 1e-4
+
+    pytorch_tensor = torch.randn(20)
+    numpy_array = np.random.randn(5)
+
+    original_data = [
+        "a",
+        {
+            1: [10, 20],
+            2: [20, 40],
+            3: numpy_array,
+        },
+        pytorch_tensor,
+    ]
+
+    arr = make_tensor(original_data, dtype=object)
+
+    # Test whether or not the data was properly cloned while putting into the ObjectArray.
+    # The elements in the ObjectArray are expected to have the same values with their originals, while not being
+    # the same objects.
+    assert arr[0] == "a"
+
+    assert isinstance(arr[1], ImmutableDict)
+    assert arr[1][1] == [10, 20]
+    assert arr[1][1] is not original_data[1][1]
+    assert isinstance(arr[1][1], ImmutableList)
+
+    assert arr[1][2] == [20, 40]
+    assert arr[1][2] is not original_data[1][2]
+    assert isinstance(arr[1][2], ImmutableList)
+
+    assert_allclose(arr[1][3], numpy_array, atol=tolerance)
+    assert arr[1][3] is not numpy_array
+    assert not arr[1][3].flags["WRITEABLE"]  # The clone of numpy_array is expected to be read-only
+
+    assert_allclose(arr[2], pytorch_tensor, atol=tolerance)
+    assert arr[2] is not pytorch_tensor
+    assert isinstance(arr[2], ReadOnlyTensor)  # The clone of pytorch_tensor is expected to be read-only
+
+    # Now we use the `.clone()` method to obtain a mutable clone of the ObjectArray
+    mutable_clone = arr.clone()
+
+    # The elements in the newly made mutable clone are expected to be copies of the original data.
+    # These elements are expected to have the same values with their originals, while not being the same objects.
+
+    assert isinstance(mutable_clone, np.ndarray)
+    assert mutable_clone.flags["WRITEABLE"]
+    assert mutable_clone[0] == "a"
+
+    assert isinstance(mutable_clone[1], dict)
+    assert mutable_clone[1][1] == [10, 20]
+    assert isinstance(mutable_clone[1][1], list)
+    assert mutable_clone[1][1] is not arr[1][1]
+    assert mutable_clone[1][1] is not original_data[1][1]
+
+    assert mutable_clone[1][2] == [20, 40]
+    assert isinstance(mutable_clone[1][2], list)
+    assert mutable_clone[1][2] is not arr[1][2]
+    assert mutable_clone[1][2] is not original_data[1][2]
+
+    assert_allclose(mutable_clone[1][3], numpy_array, atol=tolerance)
+    assert mutable_clone[1][3] is not arr[1][3]
+    assert mutable_clone[1][3] is not numpy_array
+
+    assert_allclose(mutable_clone[2], pytorch_tensor, atol=tolerance)
+    assert mutable_clone[2] is not arr[2]
+    assert mutable_clone[2] is not pytorch_tensor
+
+
+def _assert_equals_but_not_same(a, b, atol=None):
+    assert a is not b
+    if atol is None:
+        assert a == b
+    else:
+        assert_allclose(a, b, atol=atol)
+
+
+class CloningMethods:
+    @staticmethod
+    def clone_via_method(x):
+        return x.clone()
+
+    @staticmethod
+    def clone_via_copy(x):
+        return copy(x)
+
+    @staticmethod
+    def clone_via_deepcopy(x):
+        return deepcopy(x)
+
+    @staticmethod
+    def clone_via_clone_func(x):
+        from evotorch.tools import clone
+
+        return clone(x)
+
+    @staticmethod
+    def deep_clone(x):
+        return deep_clone(x, otherwise_deepcopy=True)
+
+    @staticmethod
+    def pickle_and_unpickle(x):
+        return pickle.loads(pickle.dumps(x))
+
+
+@pytest.mark.parametrize(
+    "clone_func",
+    [
+        CloningMethods.clone_via_clone_func,
+        CloningMethods.deep_clone,
+    ],
+)
+def test_cloning_container_with_cycle(clone_func):
+    tolerance = 1e-4
+
+    pytorch_tensor = torch.randn(5)
+
+    a = {"a": 1, "b": pytorch_tensor, "c": [1, 2], "d": pytorch_tensor}
+    a["c"].append(a)
+    a["e"] = a["c"]
+
+    MyNamedTuple = namedtuple("MyNamedTuple", ("aa", "bb"))
+    a["f"] = MyNamedTuple(100, 200)
+    a["g"] = a["f"]
+
+    clone_of_a = clone_func(a)
+
+    assert a is not clone_of_a
+
+    assert set(a.keys()) == set(clone_of_a.keys())
+
+    assert a["a"] == clone_of_a["a"]
+    _assert_equals_but_not_same(a["b"], clone_of_a["b"], atol=tolerance)
+
+    assert a["c"] is not clone_of_a["c"]
+    assert a["c"][:2] == clone_of_a["c"][:2]
+    assert clone_of_a["c"][2] is clone_of_a
+
+    # Assert that the namedtuple was cloned correctly
+    assert clone_of_a["f"] is not a["f"]
+    assert clone_of_a["g"] is not a["g"]
+    assert clone_of_a["f"] == a["f"]
+    assert set(clone_of_a["f"]._fields) == set(a["f"]._fields)
+
+    # Some elements in the original object are expected to be referred to twice, just like how their original
+    # counterparts were referred to twice.
+    assert clone_of_a["b"] is clone_of_a["d"]
+    assert clone_of_a["c"] is clone_of_a["e"]
+    assert clone_of_a["f"] is clone_of_a["g"]
+
+
+@pytest.mark.parametrize(
+    "clone_func",
+    [
+        CloningMethods.clone_via_clone_func,
+        CloningMethods.clone_via_copy,
+        CloningMethods.clone_via_deepcopy,
+        CloningMethods.clone_via_method,
+        CloningMethods.deep_clone,
+        CloningMethods.pickle_and_unpickle,
+    ],
+)
+def test_cloning_problem_with_cycle(clone_func):
+    tolerance = 1e-4
+
+    problem = Problem(
+        "min",
+        torch.linalg.norm,
+        initial_bounds=(-1.0, 1.0),
+        solution_length=5,
+        dtype="float32",
+    )
+
+    some_tensor = torch.FloatTensor([10, 20, 30])
+    some_data = (some_tensor[:], [1, 2, problem])
+    problem.some_tensor = some_tensor
+    problem.some_data = some_data
+
+    clone_of_problem = clone_func(problem)
+
+    assert_allclose(clone_of_problem.some_tensor, problem.some_tensor, atol=tolerance)
+    assert_allclose(clone_of_problem.some_data[0], problem.some_data[0], atol=tolerance)
+    assert_allclose(clone_of_problem.some_tensor, clone_of_problem.some_data[0], atol=tolerance)
+
+    # Check whether or not the cloning was done correctly
+    assert len(clone_of_problem.some_data) == len(problem.some_data)
+    assert len(clone_of_problem.some_data[-1]) == len(problem.some_data[-1])
+    assert clone_of_problem.some_data[-1][0] == problem.some_data[-1][0]
+    assert clone_of_problem.some_data[-1][1] == problem.some_data[-1][1]
+
+    # Although their values are the same, the inner list of `some_data` must be a clone (not the same object)
+    assert clone_of_problem.some_data[-1] is not problem.some_data[-1]
+
+    # The clone of the problem object is expected to point to itself like the original one does
+    assert clone_of_problem is not problem
+    assert clone_of_problem.some_data[-1][-1] is clone_of_problem
+
+    # After the cloning, we expect that the tensors are independent: they do not share storage anymore
+    clone_of_problem.some_tensor[:] = -1
+    clone_of_problem.some_data[0][:] = 1
+    assert_eachclose(clone_of_problem.some_tensor, -1, atol=tolerance)
+    assert_eachclose(clone_of_problem.some_data[0], 1, atol=tolerance)
+
+
+@pytest.mark.parametrize(
+    "clone_func,expect_mutable",
+    [
+        (CloningMethods.clone_via_clone_func, False),
+        (CloningMethods.clone_via_copy, False),
+        (CloningMethods.clone_via_deepcopy, False),
+        (CloningMethods.clone_via_method, True),
+        (CloningMethods.deep_clone, False),
+        (CloningMethods.pickle_and_unpickle, False),
+    ],
+)
+def test_cloning_objectarray_with_cycles(clone_func, expect_mutable):
+    # In this test, we prepare a list with self cycles in it.
+    # We first clone it by putting into an ObjectArray.
+    # We then clone this ObjectArray again by using various cloning methods.
+    # If all of our cloning methods are implemented correctly, we will get the expected results listed below.
+
+    tolerance = 1e-4
+
+    pytorch_tensor = torch.randn(20)
+    numpy_array = np.random.randn(5)
+
+    original_data = [
+        "one",
+        "two",
+        pytorch_tensor,
+    ]
+
+    inside_dict = {
+        "a": 1,
+        "b": 2,
+        "c": numpy_array,
+    }
+
+    inside_dict["d"] = inside_dict
+
+    original_data.append(inside_dict)
+    original_data.append(original_data)
+    original_data.append(numpy_array)
+
+    # The final state of original_data is:
+    #
+    # [
+    #     "one",                         # 0
+    #     "two",                         # 1
+    #     pytorch_tensor,                # 2
+    #     {                              # 3
+    #         "a": 1,
+    #         "b": 2,
+    #         "c": numpy_array,
+    #         "d": <the dict itself>,
+    #     },
+    #     <the list itself>,             # 4
+    #     numpy_array,                   # 5
+    # ]
+
+    arr = make_tensor(original_data, dtype=object)
+    clone_of_arr = clone_func(arr)
+
+    # The clone of the array is expected to have the same number of elements
+    assert len(clone_of_arr) == len(arr)
+
+    # The clone of the inner dictionary is expected to have the same keys
+    assert set(clone_of_arr[3].keys()) == set(arr[3].keys())
+
+    # The integers stored via the keys "a" and "b" in the cloned dictionary must be equal
+    assert clone_of_arr[3]["a"] == arr[3]["a"]
+    assert clone_of_arr[3]["b"] == arr[3]["b"]
+
+    # The numpy array was referred to in the original array twice.
+    # We expect that the clone of the original array also refers to its own numpy array clone twice.
+    assert isinstance(clone_of_arr[3]["c"], np.ndarray)
+    assert isinstance(clone_of_arr[5], np.ndarray)
+    assert clone_of_arr[3]["c"] is clone_of_arr[5]
+
+    # We expect that the numpy array was also cloned. It is not the same with its original.
+    assert_allclose(clone_of_arr[5], numpy_array, atol=tolerance)
+    assert clone_of_arr[5] is not numpy_array
+    assert clone_of_arr[5] is not arr[5]
+
+    # We expect that the pytorch tensor was also cloned. It is not the same with its original.
+    assert_allclose(clone_of_arr[2], pytorch_tensor, atol=tolerance)
+    assert isinstance(clone_of_arr[2], torch.Tensor)
+    assert clone_of_arr[2] is not pytorch_tensor
+    assert clone_of_arr[2] is not arr[2]
+
+    if expect_mutable:
+        assert isinstance(clone_of_arr, np.ndarray)
+        assert not isinstance(clone_of_arr[2], ReadOnlyTensor)
+        assert isinstance(clone_of_arr[3], dict)
+    else:
+        assert isinstance(clone_of_arr, ObjectArray)
+        assert isinstance(clone_of_arr[2], ReadOnlyTensor)
+        assert isinstance(clone_of_arr[3], ImmutableDict)
+        assert isinstance(clone_of_arr[4], ObjectArray)
+        assert isinstance(clone_of_arr[5], np.ndarray)
+
+        if clone_func is not CloningMethods.pickle_and_unpickle:
+            assert not clone_of_arr[5].flags["WRITEABLE"]
+
+
+@pytest.mark.parametrize(
+    "distcls,clone_func",
+    itertools.product(
+        (SeparableGaussian, SymmetricSeparableGaussian, ExpGaussian, ExpSeparableGaussian),
+        (
+            CloningMethods.clone_via_clone_func,
+            CloningMethods.clone_via_copy,
+            CloningMethods.clone_via_deepcopy,
+            CloningMethods.clone_via_method,
+            CloningMethods.pickle_and_unpickle,
+        ),
+    ),
+)
+def test_cloning_gaussian_distribution(distcls, clone_func):
+    tolerance = 1e-4
+
+    n = 20
+    mu = torch.randn(n)
+    sigma = torch.randn(n)
+    params = {"mu": mu, "sigma": sigma}
+
+    dist = distcls(params)
+    clone_of_dist = clone_func(dist)
+
+    mu = dist.mu
+    sigma = dist.sigma
+
+    clone_of_mu = clone_of_dist.mu
+    clone_of_sigma = clone_of_dist.sigma
+
+    _assert_equals_but_not_same(clone_of_mu, mu, atol=tolerance)
+    _assert_equals_but_not_same(clone_of_sigma, sigma, atol=tolerance)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
 from copy import copy, deepcopy
 from itertools import product
 from typing import Callable, Iterable, Optional, Union
@@ -26,17 +27,29 @@ from evotorch.tools.objectarray import ObjectArray
 
 
 class CloningMethods:
+    @staticmethod
     def clone_via_method(x):
         return x.clone()
 
+    @staticmethod
     def clone_via_copy(x):
         return copy(x)
 
+    @staticmethod
     def clone_via_deepcopy(x):
         return deepcopy(x)
 
+    @staticmethod
     def clone_via_clone_func(x):
         return ett.clone(x)
+
+    @staticmethod
+    def deep_clone(x):
+        return ett.cloning.deep_clone(x, otherwise_deepcopy=True)
+
+    @staticmethod
+    def pickle_and_unpickle(x):
+        return pickle.loads(pickle.dumps(x))
 
 
 class DummyProblems:
@@ -296,6 +309,8 @@ def test_batch_slicing():
         CloningMethods.clone_via_copy,
         CloningMethods.clone_via_deepcopy,
         CloningMethods.clone_via_method,
+        CloningMethods.deep_clone,
+        CloningMethods.pickle_and_unpickle,
     ],
 )
 def test_batch_cloning(clone_func):
@@ -393,6 +408,7 @@ def test_solutions_referring_to_batch():
         CloningMethods.clone_via_copy,
         CloningMethods.clone_via_deepcopy,
         CloningMethods.clone_via_method,
+        CloningMethods.deep_clone,
     ],
 )
 def test_solution_cloning(clone_func):

--- a/tests/test_objectarray.py
+++ b/tests/test_objectarray.py
@@ -119,7 +119,7 @@ def test_cloning2():
 def test_immutability():
     # Prepare data to put into an ObjectArray
     a = set([1, 2])
-    b = {"x": 3, "y": [4, 5], "z": (6, 7)}
+    b = {"x": 3, "y": [4, 5], "z": [6, 7]}
 
     # Make a new ObjectArray
     objs = make_tensor([a, b], dtype=object)
@@ -132,7 +132,7 @@ def test_immutability():
     assert isinstance(objs[0], imm.ImmutableSet)
     assert isinstance(objs[1], imm.ImmutableDict)
     assert isinstance(objs[1]["y"], imm.ImmutableList)
-    assert isinstance(objs[1]["z"], imm.ImmutableTuple)
+    assert isinstance(objs[1]["z"], imm.ImmutableList)
 
     # An ObjectArray can be converted to a numpy array
     objs2 = objs.numpy()
@@ -145,7 +145,7 @@ def test_immutability():
     assert isinstance(objs2[0], set)
     assert isinstance(objs2[1], dict)
     assert isinstance(objs2[1]["y"], list)
-    assert isinstance(objs2[1]["z"], tuple)
+    assert isinstance(objs2[1]["z"], list)
 
     # The immutable elements in the ObjectArray cannot be modified
     with pytest.raises(AttributeError):

--- a/tests/test_tensors_in_container.py
+++ b/tests/test_tensors_in_container.py
@@ -1,0 +1,177 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import torch
+
+from evotorch.testing import assert_allclose
+from evotorch.tools import cast_tensors_in_container, device_of_container, dtype_of_container
+
+
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float64, torch.int32, torch.int64))
+def test_dtype_of_container(dtype):
+    x = {
+        "a": torch.tensor([1, 2, 3], dtype=dtype),
+        "b": [1, 2],
+        "c": (
+            torch.tensor([10, 20], dtype=dtype),
+            "some string",
+        ),
+    }
+
+    assert dtype_of_container(x) == dtype
+
+
+@pytest.mark.parametrize("dtype", (torch.float32, torch.float64, torch.int32, torch.int64))
+def test_dtype_of_container_cyclic(dtype):
+    x = {
+        "a": torch.tensor([1, 2, 3], dtype=dtype),
+        "b": [1, 2],
+        "c": (
+            torch.tensor([10, 20], dtype=dtype),
+            "some string",
+        ),
+    }
+
+    x["b"].append(x)
+    x["d"] = x["a"]
+
+    assert dtype_of_container(x) == dtype
+
+
+def test_dtype_of_container_none():
+    x = {
+        "a": [1, 2, 3],
+        "b": [1, 2],
+        "c": (
+            [10, 20],
+            "some string",
+        ),
+    }
+
+    x["b"].append(x)
+    x["d"] = x["a"]
+
+    assert dtype_of_container(x) is None
+
+
+def test_device_of_container():
+    device = torch.device("cpu")
+
+    x = {
+        "a": torch.tensor([1, 2, 3], device=device),
+        "b": [1, 2],
+        "c": (
+            torch.tensor([10, 20], device=device),
+            "some string",
+        ),
+    }
+
+    assert device_of_container(x) == device
+
+
+def test_device_of_container_cyclic():
+    device = torch.device("cpu")
+
+    x = {
+        "a": torch.tensor([1, 2, 3], device=device),
+        "b": [1, 2],
+        "c": (
+            torch.tensor([10, 20], device=device),
+            "some string",
+        ),
+    }
+
+    x["b"].append(x)
+    x["d"] = x["a"]
+
+    assert device_of_container(x) == device
+
+
+def test_device_of_container_none():
+    x = {
+        "a": [1, 2, 3],
+        "b": [1, 2],
+        "c": (
+            [10, 20],
+            "some string",
+        ),
+    }
+
+    x["b"].append(x)
+    x["d"] = x["a"]
+
+    assert device_of_container(x) is None
+
+
+def _assert_equals_but_not_same(a, b, atol):
+    assert a is not b
+    assert_allclose(a, b, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "from_dtype,to_dtype",
+    (
+        (torch.float32, torch.float64),
+        (torch.float64, torch.float32),
+    ),
+)
+def test_cast_tensors_in_container(from_dtype, to_dtype):
+    tolerance = 1e-4
+
+    x = {
+        "a": torch.randn(10, dtype=from_dtype),
+        "b": [1, 2],
+        "c": (
+            torch.randn(5, dtype=from_dtype),
+            "some string",
+        ),
+    }
+
+    # Make another element point to an existing tensor
+    x["d"] = x["c"][0]
+
+    # Introduce a cyclic reference
+    x["e"] = x
+
+    # Cast all the tensors in x
+    y = cast_tensors_in_container(x, dtype=to_dtype)
+
+    # Assert that the resulting dictionary has the same keys with the original
+    assert set(y.keys()) == set(x.keys())
+
+    # Assert that the resulting dictionary is NOT the same dictionary with the original
+    assert y is not x
+
+    # Assert that the cloning was done correctly
+    assert isinstance(y["a"], torch.Tensor)
+    _assert_equals_but_not_same(y["a"], x["a"], atol=tolerance)
+
+    assert isinstance(y["b"], list)
+    assert y["b"] is not x["b"]
+    assert len(y["b"]) == len(x["b"])
+    assert y["b"] == x["b"]
+
+    assert isinstance(y["c"], tuple)
+    assert y["c"] is not x["c"]
+    assert len(y["c"]) == len(x["c"])
+    _assert_equals_but_not_same(y["c"][0], x["c"][0], atol=tolerance)
+    assert y["c"][1] == x["c"][1]
+
+    assert y["d"] is not x["d"]
+    assert y["d"] is y["c"][0]
+
+    assert y["e"] is not x
+    assert y["e"] is y


### PR DESCRIPTION
The main purpose of this pull request is to increase the correctness when cloning and/or pickling instances of Problem, Solution, SolutionBatch, ObjectArray, and ImmutableContainer. When cloning and/or pickling, two new behaviors are introduced:
(i) PyTorch tensors are cut off from their original storages (to avoid small slices from carrying their original storages with themselves); and
(ii) self references within these mentioned objects are specially handled, and therefore, many unwanted RecursionError scenarios which could previously happen are now avoided.

**New function: `deep_clone(...)`**

This new function creates a deep copy of a Python container (which can contain other containers or PyTorch tensors or numpy arrays). While traversing through the container, any PyTorch tensors will be copied using the `.clone()` method, which means, in the newly created clone, the PyTorch tensors will be independent copies without extra storage.

**New base class: `Clonable`**

Any subclass of `Clonable` is expected to override the method `_get_cloned_state(...)`. This method is expected to return the state of the object in a dictionary. The `Clonable` base class provides definitions for the methods `__copy__(...)` and `__deepcopy__(...)` where the dictionary made by `_get_cloned_state(...)` is used to create the clone.

**New base class: `Serializable`**

This is a subclass of Clonable, which is meant to be used as a base class. In addition to the method definitions made by `Clonable` (`__copy__` and `__deepcopy__`), this base class also defines `__getstate__` so that the method `_get_cloned_state(...)` also affects how the inheriting class is pickled.

**Classes inheriting from `Serializable`**

The following classes now inherit from `Serializable`:

 - Problem
 - Solution
 - SolutionBatch
 - Distribution

Each of these mentioned classes have their own definitions for `_get_cloned_state(...)`, and use `deep_clone(...)` for preparing their state dictionaries. Therefore, at the moment of cloning and pickling, the stored tensors are subject to the `.clone()` method and they are cut off from their original storages. With this feature, when a relatively small slice of a large SolutionBatch is cloned or pickled, the serialized slice will not contain the entire storage of the original batch.

**New base class: `ReadOnlyClonable`**

This is like `Clonable`, but requires the inheriting class to also define a method called `_get_mutable_clone()` so that the object knows how its mutable counterpart can be constructed. ImmutableContainer objects are now ReadOnlyClonable.