### PR TITLE
Fix the signature of `_do_cross_over(...)`

### DIFF
--- a/src/evotorch/operators/base.py
+++ b/src/evotorch/operators/base.py
@@ -365,7 +365,6 @@ class CrossOver(CopyingOperator):
 
     def _do_cross_over(
         self,
-        batch: SolutionBatch,
         parents1: Union[torch.Tensor, ObjectArray],
         parents2: Union[torch.Tensor, ObjectArray],
     ) -> SolutionBatch:
@@ -375,10 +374,9 @@ class CrossOver(CopyingOperator):
         This is a protected method, meant to be overriden by the inheriting
         subclass.
 
-        The arguments passed to this function are the original population
-        as a batch, and the decision values of the first and the second half
-        of the selected parents, both as PyTorch tensors or as
-        `ObjectArray`s.
+        The arguments passed to this function are the decision values of the
+        first and the second half of the selected parents, both as PyTorch
+        tensors or as `ObjectArray`s.
 
         In the overriding function, for each integer i, one is expected to
         recombine the values of the i-th row of `parents1` with the values of
@@ -388,7 +386,6 @@ class CrossOver(CopyingOperator):
         all the recombination results into the values of that new batch.
 
         Args:
-            batch: The original population, as a SolutionBatch.
             parents1: The decision values of the first half of the
                 selected parents.
             parents2: The decision values of the second half of the


### PR DESCRIPTION
The `CrossOver` base class has a method `_do_cross_over(...)` that is meant to be overriden by the inheriting classes. Although the documentation and the initial signature of `_do_cross_over(...)` claims that the expected arguments are `batch` (the original `SolutionBatch`), `parents1` (decision values of the first half of the selected parents) and `parents2` (decision values of the second half of the selected parents), what the class `CrossOver` actually does is to call it only with the arguments `parents1` and `parents2` (this can be confirmed by looking at the `_do(...)` method of `CrossOver`). All our `CrossOver` subclasses also define their implementations of `_do_cross_over(...)` with the arguments `parents1` and `parents2` only. Therefore, the initial signature of `_do_cross_over(...)` and its docstring are misleading. This pull request aims to fix those misleading elements.