### PR TITLE
fix: Fix all the mkdocstrings warnings

### DIFF
--- a/src/evotorch/algorithms/distributed/gaussian.py
+++ b/src/evotorch/algorithms/distributed/gaussian.py
@@ -610,8 +610,6 @@ class PGPE(GaussianSearchAlgorithm):
                 the default value for this setting is 0.2, meaning that
                 the update on the standard deviation values can not be
                 more than 20% of their original values.
-            device: The device in which the population is to be stored.
-                The default value is 'cpu'.
             symmetric: Whether or not the solutions will be sampled
                 in a symmetric/mirrored/antithetic manner.
                 The default is True.
@@ -1270,14 +1268,6 @@ class XNES(GaussianSearchAlgorithm):
                 Can be given as None if no such ranking is required.
             center_init: The initial center solution.
                 Can be left as None.
-            stdev_min: Minimum values for the standard deviation.
-                Expected as a 1-dimensional array to serve as a limiter
-                to the diagonals of the covariance matrix's square root.
-            stdev_max: Maximum values for the standard deviation.
-                Expected as a 1-dimensional array to serve as a limiter
-                to the diagonals of the covariance matrix's square root.
-            stdev_max_change: Maximum change allowed for when updating
-                the square roort of the covariance matrix.
             obj_index: Index of the objective according to which the
                 gradient estimations will be done.
                 For single-objective problems, this can be left as None.

--- a/src/evotorch/core.py
+++ b/src/evotorch/core.py
@@ -1953,7 +1953,7 @@ class Problem(TensorMakerMixin, Serializable):
         Evaluate the given Solution or SolutionBatch.
 
         Args:
-            batch: The SolutionBatch to be evaluated.
+            x: The SolutionBatch to be evaluated.
         """
 
         if isinstance(x, Solution):
@@ -4219,7 +4219,7 @@ class Solution(Serializable):
         class.
 
         Args:
-            evals: New evaluation result(s) for the Solution.
+            evaluation: New evaluation result(s) for the Solution.
                 For single-objective problems, this argument can be given
                 as a scalar.
                 When this argument is given as a scalar (for single-objective

--- a/src/evotorch/neuroevolution/net/statefulmodule.py
+++ b/src/evotorch/neuroevolution/net/statefulmodule.py
@@ -86,7 +86,7 @@ class StatefulModule(nn.Module):
         self._hidden = None
 
 
-def ensure_stateful(net: nn.Module):
+def ensure_stateful(net: nn.Module) -> StatefulModule:
     """
     Ensure that a module is wrapped by StatefulModule.
 
@@ -104,3 +104,4 @@ def ensure_stateful(net: nn.Module):
     """
     if not isinstance(net, StatefulModule):
         return StatefulModule(net)
+    return net

--- a/src/evotorch/neuroevolution/net/vecrl.py
+++ b/src/evotorch/neuroevolution/net/vecrl.py
@@ -137,7 +137,10 @@ def convert_from_torch(x: torch.Tensor, array_type: str) -> Any:
         array_type: Type to which the PyTorch tensor will be converted.
             Expected as one of these strings: "jax", "torch", "numpy".
     Returns:
-
+        The array of the specified type. Can be a JAX array, a numpy array,
+        or PyTorch tensor.
+    Raises:
+        ValueError: if the array type cannot be determined.
     """
     if array_type == "torch":
         return x

--- a/src/evotorch/tools/misc.py
+++ b/src/evotorch/tools/misc.py
@@ -271,7 +271,7 @@ def is_bool(x: Any) -> bool:
         return False
 
 
-def is_integer_vector(x: Any):
+def is_integer_vector(x: Any) -> bool:
     """
     Return True if `x` is a vector consisting of integers.
 
@@ -294,7 +294,7 @@ def is_integer_vector(x: Any):
         return False
 
 
-def is_bool_vector(x: Any):
+def is_bool_vector(x: Any) -> bool:
     """
     Return True if `x` is a vector consisting of bools.
 
@@ -317,7 +317,7 @@ def is_bool_vector(x: Any):
         return False
 
 
-def is_real_vector(x: Any):
+def is_real_vector(x: Any) -> bool:
     """
     Return True if `x` is a vector consisting of real numbers.
 
@@ -611,7 +611,7 @@ def ensure_tensor_length_and_dtype(
     *,
     allow_scalar: bool = False,
     device: Optional[Device] = None,
-):
+) -> Any:
     """
     Return the given sequence as a tensor while also confirming its
     length, dtype, and device.

--- a/src/evotorch/tools/objectarray.py
+++ b/src/evotorch/tools/objectarray.py
@@ -511,7 +511,7 @@ class ObjectArray(Sequence, RecursivePrintable):
         Convert a numpy array of dtype `object` to an `ObjectArray`.
 
         Args:
-            The numpy array that will be converted to `ObjectArray`.
+            ndarray: The numpy array that will be converted to `ObjectArray`.
         Returns:
             The ObjectArray counterpart of the given numpy array.
         """


### PR DESCRIPTION
There were a lot of docstring issues, this MR fixes them all. Including a small bug that crawled into the `evotorch.neuroevolution.net.statefulmodule.ensure_stateful(...)` function.