### PR TITLE
feat: Add torch-based CMA-ES implementation

### DIFF
--- a/src/evotorch/algorithms/__init__.py
+++ b/src/evotorch/algorithms/__init__.py
@@ -19,17 +19,20 @@ evolutionary algorithms.
 
 __all__ = (
     "CMAES",
+    "PyCMAES",
     "CEM",
     "PGPE",
     "SNES",
     "XNES",
     "SteadyStateGA",
     "SearchAlgorithm",
+    "Cosyne",
 )
 
 
-from . import cmaes, distributed, ga, searchalgorithm
+from . import cmaes, distributed, ga, pycmaes, searchalgorithm
 from .cmaes import CMAES
 from .distributed import CEM, PGPE, SNES, XNES
 from .ga import Cosyne, SteadyStateGA
+from .pycmaes import PyCMAES
 from .searchalgorithm import SearchAlgorithm

--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -371,9 +371,11 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         return self._population
 
     def _get_center(self) -> torch.Tensor:
+        """Get the center of search distribution, m"""
         return self.m
 
     def _get_sigma(self) -> torch.Tensor:
+        """Get the step-size of the search distribution, sigma"""
         return self.sigma
 
     @property

--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -15,34 +15,77 @@
 # flake8: noqa: C901
 
 """
-This namespace contains the CMAES class, which is a wrapper
-for the CMA-ES implementation of the `cma` package.
+This namespace contains the CMAES class
 """
 
-import math
-from copy import copy, deepcopy
-from typing import Any, Callable, Iterable, List, Optional, Union
+from typing import Optional, Tuple
 
 import numpy as np
 import torch
 
 from ..core import Problem, SolutionBatch
-from ..tools.misc import Device, DType, RealOrVector, Vector, is_sequence, numpy_copy
+from ..tools.misc import Real, Vector
 from .searchalgorithm import SearchAlgorithm, SinglePopulationAlgorithmMixin
 
-try:
-    import cma
-except ImportError:
-    cma = None
+
+def _h_sig(p_sigma: torch.Tensor, c_sigma: float, iter: int) -> torch.Tensor:
+    """Boolean flag for stalling the update to the evolution path for rank-1 updates
+    Args:
+        p_sigma (torch.Tensor): The evolution path for step-size updates
+        c_sigma (float): The learning rate for step-size updates
+        iter (int): The current iteration (generation)
+    Returns:
+        stall (torch.Tensor): Whether to stall the update to p_c, expressed as a single torch float with 0 = continue, 1 = stall
+    """
+    # infer dimension from p_sigma
+    d = p_sigma.shape[-1]
+    # Compute the discounted squared sum
+    squared_sum = torch.norm(p_sigma).pow(2.0) / (1 - (1 - c_sigma) ** (2 * iter + 1))
+    # Check boolean flag and return
+    stall = (squared_sum / d) - 1 < 1 + 4.0 / (d + 1)
+    return stall.any().to(p_sigma.dtype)
+
+
+def _limit_stdev(sigma: torch.Tensor, C: torch.Tensor, stdev_min: Optional[float], stdev_max: Optional[float]):
+    """Limit the standard deviation of a covariance matrix sigma^2 C
+    Args:
+        sigma (torch.Tensor): The square root of the scale of the covariance matrix
+        C (torch.Tensor): The unscaled shape of the covariance matrix
+        stdev_min (Optional[float]): A lower bound on the element-wise standard deviation
+        stdev_max (Optional[float]): An upper bound on the element-wise standard deviation
+    Returns:
+        C (torch.Tensor): The updated shape of the covariance matrix, taking into account the given limits
+    """
+    if len(C.shape) == 1:
+        # Separable case
+        # Get element-wise standard deviations, with vector C assumed to be the diagonal
+        stdevs = sigma * torch.sqrt(C)
+    else:
+        # Get element-wise standard deviations by taking variances along diagonal
+        stdevs = sigma * torch.sqrt(torch.diag(C))
+
+    # Limit standard deviations
+    stdevs = torch.clamp(stdevs, min=stdev_min, max=stdev_max)
+    unscaled_stdevs = stdevs / sigma
+
+    # Construct new unscaled covariance matrix
+    if len(C.shape) == 1:
+        # Separable case
+        C = unscaled_stdevs.pow(2.0)
+    else:
+        # Non-separable case
+        C = C.clone()
+        torch.diagonal(C)[:] = unscaled_stdevs.pow(2.0)
+
+    return C
 
 
 class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
     """
     CMAES: Covariance Matrix Adaptation Evolution Strategy.
 
-    This is an interface class between the CMAES implementation
-    within the `cma` package developed within the GitHub repository
-    CMA-ES/pycma.
+    This is a GPU-accelerated and vectorized implementation, based on pycma (version r3.2.2)
+    and the below references.
 
     References:
 
@@ -54,70 +97,94 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         Nikolaus Hansen, Andreas Ostermeier (2001).
         Completely Derandomized Self-Adaptation in Evolution Strategies.
 
+        Nikolaus Hansen (2016).
+        The CMA Evolution Strategy: A Tutorial.
+
     """
 
     def __init__(
         self,
         problem: Problem,
         *,
-        stdev_init: RealOrVector,  # sigma0
-        popsize: Optional[int] = None,  # popsize
-        center_init: Optional[Vector] = None,  # x0
-        center_learning_rate: Optional[float] = None,  # CMA_cmean
-        cov_learning_rate: Optional[float] = None,  # CMA_on
-        rankmu_learning_rate: Optional[float] = None,  # CMA_rankmu
-        rankone_learning_rate: Optional[float] = None,  # CMA_rankone
-        stdev_min: Optional[Union[float, np.ndarray]] = None,  # minstd
-        stdev_max: Optional[Union[float, np.ndarray]] = None,  # maxstd
-        separable: bool = False,  # CMA_diagonal
+        stepsize_init: Real,
+        popsize: Optional[int] = None,
+        center_init: Optional[Vector] = None,
+        c_m: Real = 1.0,
+        c_sigma: Optional[Real] = None,
+        c_sigma_ratio: Real = 1.0,
+        damp_sigma: Optional[Real] = None,
+        damp_sigma_ratio: Real = 1.0,
+        c_c: Optional[Real] = None,
+        c_c_ratio: Real = 1.0,
+        c_1: Optional[Real] = None,
+        c_1_ratio: Real = 1.0,
+        c_mu: Optional[Real] = None,
+        c_mu_ratio: Real = 1.0,
+        active: bool = True,
+        csa_squared: bool = False,
+        stdev_min: Optional[Real] = None,
+        stdev_max: Optional[Real] = None,
+        separable: bool = False,
+        limit_C_decomposition: bool = True,
         obj_index: Optional[int] = None,
-        cma_options: dict = {},
     ):
         """
         `__init__(...)`: Initialize the CMAES solver.
 
         Args:
-            problem: The problem object which is being worked on.
-            stdev_init: Initial standard deviation as a scalar or
-                as a 1-dimensional array.
+            problem (Problem): The problem object which is being worked on.
+            stepsize_init (Real): Initial step-size
             popsize: Population size. Can be specified as an int,
-                or can be left as None to let the CMAES solver
-                decide the population size according to the length
-                of a solution.
+                or can be left as None in which case the CMA-ES rule of thumb is applied:
+                popsize = 4 + floor(3 log d) where d is the dimension
             center_init: Initial center point of the search distribution.
                 Can be given as a SolutionVector or as a 1-D array.
                 If left as None, an initial center point is generated
                 with the help of the problem object's `generate_values(...)`
                 method.
-            center_learning_rate: Learning rate for updating the mean
-                of the search distribution. Leaving this as None
-                means that the CMAES solver is to use its own default,
-                which is documented as 1.0.
-            cov_learning_rate: Learning rate for updating the covariance
-                matrix of the search distribution. This hyperparameter
-                acts as a common multiplier for rank_one update and rank_mu
-                update of the covariance matrix. Leaving this as None
-                means that the CMAES solver is to use its own default,
-                which is documented as 1.0.
-            rankmu_learning_rate: Learning rate for the rank_mu update
-                of the covariance matrix of the search distribution.
-                Leaving this as None means that the CMAES solver is to use
-                its own default, which is documented as 1.0.
-            rankone_learning_rate: Learning rate for the rank_one update
-                of the covariance matrix of the search distribution.
-                Leaving this as None means that the CMAES solver is to use
-                its own default, which is documented as 1.0.
-            stdev_min: Minimum allowed standard deviation of the search
+            c_m (Real): Learning rate for updating the mean
+                of the search distribution. By default the value is 1.
+
+            c_sigma (Optional[Real]): Learning rate for updating the step size. If None,
+                then the CMA-ES rules of thumb will be applied.
+            c_sigma_ratio (Real): Multiplier on the learning rate for the step size.
+                if c_sigma has been left as None, can be used to rescale the default c_sigma value.
+
+            damp_sigma (Optional[Real]): Damping factor for updating the step size. If None,
+                then the CMA-ES rules of thumb will be applied.
+            damp_sigma_ratio (Real): Multiplier on the damping factor for the step size.
+                if damp_sigma has been left as None, can be used to rescale the default damp_sigma value.
+
+            c_c (Optional[Real]): Learning rate for updating the rank-1 evolution path.
+                If None, then the CMA-ES rules of thumb will be applied.
+            c_c_ratio (Real): Multiplier on the learning rate for the rank-1 evolution path.
+                if c_c has been left as None, can be used to rescale the default c_c value.
+
+            c_1 (Optional[Real]): Learning rate for the rank-1 update to the covariance matrix.
+                If None, then the CMA-ES rules of thumb will be applied.
+            c_1_ratio (Real): Multiplier on the learning rate for the rank-1 update to the covariance matrix.
+                if c_1 has been left as None, can be used to rescale the default c_1 value.
+
+            c_mu (Optional[Real]): Learning rate for the rank-mu update to the covariance matrix.
+                If None, then the CMA-ES rules of thumb will be applied.
+            c_mu_ratio (Real): Multiplier on the learning rate for the rank-mu update to the covariance matrix.
+                if c_mu has been left as None, can be used to rescale the default c_mu value.
+
+            active (bool): Whether to use Active CMA-ES. Defaults to True, consistent with the tutorial paper and pycma.
+            csa_squared (bool): Whether to use the squared rule ("CSA_squared" in pycma) for the step-size adapation.
+                This effectively corresponds to taking the natural gradient for the evolution path on the step size,
+                rather than the default CMA-ES rule of thumb.
+
+            stdev_min (Optional[Real]): Minimum allowed standard deviation of the search
                 distribution. Leaving this as None means that no such
                 boundary is to be used.
-                Can be given as None, as a scalar, or as a 1-dimensional
-                array.
-            stdev_max: Maximum allowed standard deviation of the search
+                Can be given as None or as a scalar.
+            stdev_max (Optional[Real]): Maximum allowed standard deviation of the search
                 distribution. Leaving this as None means that no such
                 boundary is to be used.
-                Can be given as None, as a scalar, or as a 1-dimensional
-                array.
-            separable: Provide this as True if you would like the problem
+                Can be given as None or as a scalar.
+
+            separable (bool): Provide this as True if you would like the problem
                 to be treated as a separable one. Treating a problem
                 as separable means to adapt only the diagonal parts
                 of the covariance matrix and to keep the non-diagonal
@@ -125,28 +192,20 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
                 covariance matrices on which operating is computationally
                 expensive. Therefore, for such high dimensional problems,
                 setting `separable` as True might be useful.
-                If, instead, you would like to configure on which
-                iterations the diagonal parts of the covariance matrix
-                are to be adapted, then it is recommended to leave
-                `separable` as False and set a new value for the key
-                "CMA_diagonal" via `cma_options` (see the official
-                documentation of pycma for details regarding the
-                "CMA_diagonal" setting).
-            obj_index: Objective index according to which evaluation
+
+            limit_C_decomposition (bool): Whether to limit the frequency of decomposition of the shape matrix C
+                Setting this to True (default) means that C will not be decomposed every generation
+                This degrades the quality of the sampling and updates, but provides a guarantee of O(d^2) time complexity.
+                This option can be used with separable=True (e.g. for experimental reasons) but the performance will only degrade
+                without time-complexity benefits.
+
+
+            obj_index (Optional[int]): Objective index according to which evaluation
                 of the solution will be done.
-            cma_options: Any other configuration for the CMAES solver
-                can be passed via the cma_options dictionary.
         """
 
-        # Make sure that the cma module is installed
-        if cma is None:
-            raise ImportError(f"The class {type(self).__name__} is only available if the package `cma` is installed.")
-
         # Initialize the base class
-        SearchAlgorithm.__init__(self, problem, center=self._get_center)
-
-        # Initialize the population.
-        self._population: SolutionBatch = self._problem.generate_batch(popsize, empty=True)
+        SearchAlgorithm.__init__(self, problem, center=self._get_center, stepsize=self._get_sigma)
 
         # Ensure that the problem is numeric
         problem.ensure_numeric()
@@ -154,110 +213,154 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         # Store the objective index
         self._obj_index = problem.normalize_obj_index(obj_index)
 
+        # Track d = solution length for reference in initialization of hyperparameters
+        d = self._problem.solution_length
+
+        # === Initialize population ===
+        if not popsize:
+            # Default value used in CMA-ES literature 4 + floor(3 log n)
+            popsize = 4 + int(np.floor(3 * np.log(d)))
+        self.popsize = int(popsize)
+        # Half popsize, referred to as mu in CMA-ES literature
+        self.mu = int(np.floor(popsize / 2))
+        self._population = problem.generate_batch(popsize=popsize)
+
+        # === Initialize search distribution ===
+
+        self.separable = separable
+
         # If `center_init` is not given, generate an initial solution
         # with the help of the problem object.
         # Otherwise, use the given initial solution as the starting
         # point in the search space.
         if center_init is None:
-            x0 = self._problem.generate_values(1).to("cpu").view(-1).numpy().astype(dtype=float)
-        else:
-            x0 = numpy_copy(center_init, dtype=float)
+            center_init = self._problem.generate_values(1)
 
-        # Store the initial standard deviations
-        sigma0 = numpy_copy(stdev_init, dtype=float)
+        # Store the center
+        self.m = self._problem.make_tensor(center_init)
 
-        # Generate an options dictionary to pass to the cma solver.
-        inopts = {}
-        for k, v in cma_options.items():
-            if isinstance(v, torch.Tensor):
-                v = numpy_copy(v, dtype=float)
-            inopts[k] = v
+        # Store the initial step size
+        self.sigma = self._problem.make_tensor(stepsize_init)
 
-        # Remove the number of iterations boundary
-        if "maxiter" not in inopts:
-            inopts["maxiter"] = np.inf
-
-        # Below is a temporary helper function for safely storing the configuration items.
-        # This inner function updates the `inopts` variable.
-        def store_opt(key: str, long_name: str, value: Any, converter: Callable):
-            # Here, `key` represents the configuration key used by pycma
-            # `long_name` represents the configuration's long name used by this class
-            # `value` is the configuration value associated with `key`.
-
-            # Declare that this inner function accesses the `inopts` variable.
-            nonlocal inopts
-
-            if value is None:
-                # If the provided `value` is None, then there is no configuration to store.
-                # So, we just leave this inner function.
-                return
-
-            if key in inopts:
-                # If the given `key` already exists within `inopts`, this means that the configuration was specified
-                # twice: via the keyword argument `cma_options` AND via a keyword argument.
-                # We raise an error and inform the user about this redundancy.
-                raise ValueError(
-                    f"The configuration {repr(key)} was redundantly provided"
-                    f" both via the initialization argument {long_name}"
-                    f" and via the cma_options dictionary."
-                    f" {long_name}={repr(value)};"
-                    f" cma_options[{repr(key)}]={repr(inopts[key])}."
-                )
-
-            inopts[key] = converter(value)
-
-        # Temporary helper function which makes sure that `x` is a numpy array or a float.
-        def array_or_float(x):
-            if is_sequence(x):
-                return numpy_copy(x)
-            else:
-                return float(x)
-
-        # Store the cma configuration received through the initialization arguments (and raise error if there is
-        # redundancy with the cma_options dictionary).
-        store_opt("popsize", "popsize", popsize, int)
-        store_opt("CMA_cmean", "center_learning_rate", center_learning_rate, float)
-        store_opt("CMA_on", "cov_learning_rate", cov_learning_rate, float)
-        store_opt("CMA_rankmu", "rankmu_learning_rate", rankmu_learning_rate, float)
-        store_opt("CMA_rankone", "rankone_learning_rate", rankone_learning_rate, float)
-        store_opt("minstd", "stdev_min", stdev_min, array_or_float)
-        store_opt("maxstd", "stdev_max", stdev_max, array_or_float)
         if separable:
-            store_opt("CMA_diagonal", "separable", separable, bool)
+            # Initialize C as the diagonal vector. Note that when separable, the eigendecomposition is not needed
+            self.C = self._problem.make_ones(d)
+            # In this case A is simply the square root of elements of C
+            self.A = self._problem.make_ones(d)
+        else:
+            # Initialize C = AA^T all diagonal.
+            self.C = torch.eye(d, dtype=problem.dtype, device=problem.device)
+            self.A = self.C.clone()
 
-        # If the problem defines lower and upper bounds, pass these into the options dict.
-        def process_bounds(bounds: RealOrVector) -> np.ndarray:
-            if bounds is None:
-                return None
+        # === Initialize raw weights ===
+        # Conditioned on popsize
+
+        # w_i = log((lambda + 1) / 2) - log(i) for i = 1 ... lambda
+        raw_weights = self.problem.make_tensor(np.log((popsize + 1) / 2) - torch.log(torch.arange(popsize) + 1))
+        # positive valued weights are the first mu
+        positive_weights = raw_weights[: self.mu]
+        negative_weights = raw_weights[self.mu :]
+
+        # Variance effective selection mass of positive weights
+        # Not affected by future updates to raw_weights
+        self.mu_eff = torch.sum(positive_weights).pow(2.0) / torch.sum(positive_weights.pow(2.0))
+
+        # === Initialize search parameters ===
+        # Conditioned on weights
+
+        # Store fixed information
+        self.c_m = c_m
+        self.active = active
+        self.csa_squared = csa_squared
+        self.stdev_min = stdev_min
+        self.stdev_max = stdev_max
+
+        # Learning rate for step-size adaption
+        if c_sigma is None:
+            c_sigma = (self.mu_eff + 2.0) / (d + self.mu_eff + 3)
+        self.c_sigma = c_sigma_ratio * c_sigma
+
+        # Damping factor for step-size adapation
+        if damp_sigma is None:
+            damp_sigma = 1 + 2 * max(0, torch.sqrt((self.mu_eff - 1) / (d + 1)) - 1) + self.c_sigma
+        self.damp_sigma = damp_sigma_ratio * damp_sigma
+
+        # Learning rate for evolution path for rank-1 update
+        if c_c is None:
+            # Branches on separability
+            if separable:
+                c_c = (1 + (1 / d) + (self.mu_eff / d)) / (d**0.5 + (1 / d) + 2 * (self.mu_eff / d))
             else:
-                if is_sequence(bounds):
-                    bounds = numpy_copy(bounds)
-                else:
-                    bounds = np.array(float(bounds)).repeat(self._problem.solution_length)
-                return bounds
+                c_c = (4 + self.mu_eff / d) / (d + (4 + 2 * self.mu_eff / d))
+        self.c_c = c_c_ratio * c_c
 
-        lb = process_bounds(self._problem.lower_bounds)
-        ub = process_bounds(self._problem.upper_bounds)
+        # Learning rate for rank-1 update to covariance matrix
+        if c_1 is None:
+            # Branches on separability
+            if separable:
+                c_1 = 1.0 / (d + 2.0 * np.sqrt(d) + self.mu_eff / d)
+            else:
+                c_1 = min(1, popsize / 6) * 2 / ((d + 1.3) ** 2.0 + self.mu_eff)
+        self.c_1 = c_1_ratio * c_1
 
-        register_bounds = False
-        if lb is not None and ub is None:
-            ub = np.array(np.inf).repeat(self._problem.solution_length)
-            register_bounds = True
-        elif lb is None and ub is not None:
-            lb = np.array(-(np.inf)).repeat(self._problem.solution_length)
-            register_bounds = True
-        elif lb is not None and ub is not None:
-            register_bounds = True
+        # Learning rate for rank-mu update to covariance matrix
+        if c_mu is None:
+            # Branches on separability
+            if separable:
+                c_mu = (0.25 + self.mu_eff + (1.0 / self.mu_eff) - 2) / (d + 4 * np.sqrt(d) + (self.mu_eff / 2.0))
+            else:
+                c_mu = min(
+                    1 - self.c_1, 2 * ((0.25 + self.mu_eff - 2 + (1 / self.mu_eff)) / ((d + 2) ** 2.0 + self.mu_eff))
+                )
+        self.c_mu = c_mu_ratio * c_mu
 
-        if register_bounds:
-            inopts["bounds"] = [lb, ub]
+        # The 'variance aware' coefficient used for the additive component of the evolution path for sigma
+        self.variance_discount_sigma = torch.sqrt(self.c_sigma * (2 - self.c_sigma) * self.mu_eff)
+        # The 'variance aware' coefficient used for the additive component of the evolution path for rank-1 updates
+        self.variance_discount_c = torch.sqrt(self.c_c * (2 - self.c_c) * self.mu_eff)
 
-        # Generate a random seed using the problem object for the sake of reproducibility.
-        if "seed" not in inopts:
-            inopts["seed"] = int(self._problem.make_randint(tuple(), n=(2**32) - 100) + 100)
+        # === Finalize weights ===
+        # Conditioned on search parameters and raw weights
 
-        # Instantiate the CMAEvolutionStrategy with the prepared configuration items.
-        self._es = cma.CMAEvolutionStrategy(x0, sigma0, inopts)
+        # Positive weights always sum to 1
+        positive_weights = positive_weights / torch.sum(positive_weights)
+
+        if self.active:
+            # Active CMA-ES: negative weights sum to alpha
+
+            # Get the variance effective selection mass of negative weights
+            mu_eff_neg = torch.sum(negative_weights).pow(2.0) / torch.sum(negative_weights.pow(2.0))
+
+            # Alpha is the minimum of the following 3 terms
+            alpha_mu = 1 + self.c_1 / self.c_mu
+            alpha_mu_eff = 1 + 2 * mu_eff_neg / (self.mu_eff + 2)
+            alpha_pos_def = (1 - self.c_mu - self.c_1) / (d * self.c_mu)
+            alpha = min([alpha_mu, alpha_mu_eff, alpha_pos_def])
+
+            # Rescale negative weights
+            negative_weights = alpha * negative_weights / torch.sum(torch.abs(negative_weights))
+        else:
+            # Negative weights are simply zero
+            negative_weights = torch.zeros_like(negative_weights)
+
+        # Concatenate final weights
+        self.weights = torch.cat([positive_weights, negative_weights], dim=-1)
+
+        # === Some final setup ===
+
+        # Initialize the evolution paths
+        self.p_sigma = 0.0
+        self.p_c = 0.0
+
+        # Hansen's approximation to the expectation of ||x|| x ~ N(0, I_d).
+        # Note that we could use the exact formulation with Gamma functions, but we'll retain this form for consistency
+        self.unbiased_expectation = np.sqrt(d) * (1 - (1 / (4 * d)) + 1 / (21 * d**2))
+
+        # How often to decompose C
+        if limit_C_decomposition:
+            self.decompose_C_freq = max(1, int(1 / np.floor(10 * d * (self.c_1 + self.c_mu))))
+        else:
+            self.decompose_C_freq = 1
 
         # Use the SinglePopulationAlgorithmMixin to enable additional status reports regarding the population.
         SinglePopulationAlgorithmMixin.__init__(self)
@@ -267,20 +370,213 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         """Population generated by the CMA-ES algorithm"""
         return self._population
 
-    def _step(self):
-        """Perform a step of the CMA-ES solver"""
-        asked = self._es.ask()
-        self._population.access_values()[:] = torch.as_tensor(
-            np.asarray(asked), dtype=self._problem.dtype, device=self._population.device
-        )
-        self._problem.evaluate(self._population)
-        scores = numpy_copy(self._population.utility(self._obj_index), dtype=float)
-        self._es.tell(asked, -1.0 * scores)
-
     def _get_center(self) -> torch.Tensor:
-        return torch.as_tensor(self._es.result[5], dtype=self._population.dtype, device=self._population.device)
+        return self.m
+
+    def _get_sigma(self) -> torch.Tensor:
+        return self.sigma
 
     @property
     def obj_index(self) -> int:
         """Index of the objective being focused on"""
         return self._obj_index
+
+    def sample_distribution(self, num_samples: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Sample the population. All 3 representations of solutions are returned for easy calculations of updates.
+        Note that the computation time of this operation of O(d^2 num_samples) unless separable, in which case O(d num_samples)
+        Args:
+            num_samples (Optional[int]): The number of samples to draw. If None, then the population size is used
+        Returns:
+            zs (torch.Tensor): A tensor of shape [num_samples, d] of samples from the local coordinate space e.g. z_i ~ N(0, I_d)
+            ys (torch.Tensor): A tensor of shape [num_samples, d] of samples from the shaped coordinate space e.g. y_i ~ N(0, C)
+            xs (torch.Tensor): A tensor of shape [num_samples, d] of samples from the search space e.g. x_i ~ N(m, sigma^2 C)
+        """
+        if num_samples is None:
+            num_samples = self.popsize
+        # Generate z values
+        zs = self._problem.make_gaussian(num_solutions=num_samples)
+        # Construct ys = A zs
+        if self.separable:
+            # In the separable case A is diagonal so is represented as a single vector
+            ys = self.A.unsqueeze(0) * zs
+        else:
+            ys = (self.A @ zs.T).T
+        # Construct xs = m + sigma ys
+        xs = self.m.unsqueeze(0) + self.sigma * ys
+        return zs, ys, xs
+
+    def get_population_weights(self, xs: torch.Tensor) -> torch.Tensor:
+        """Get the assigned weights of the population (e.g. evaluate, rank and return)
+        Args:
+            xs (torch.Tensor): The population samples drawn from N(mu, sigma^2 C)
+        Returns:
+            assigned_weights (torch.Tensor): A [popsize, ] dimensional tensor of ordered weights
+        """
+        # Computation is O(popsize * F_time) where F_time is the evalutation time per sample
+        # Fill the population
+        self._population.set_values(xs)
+        # Evaluate the current population
+        self.problem.evaluate(self._population)
+        # Sort the population
+        indices = self._population.argsort(obj_index=self.obj_index)
+        # Invert the sorting of the population to obtain the ranks
+        # Note that these ranks start at zero, but this is fine as we are just using them for indexing
+        ranks = torch.zeros_like(indices)
+        ranks[indices] = torch.arange(self.popsize, dtype=indices.dtype, device=indices.device)
+        # Get weights corresponding to each rank
+        assigned_weights = self.weights[ranks]
+        return assigned_weights
+
+    def update_m(self, zs: torch.Tensor, ys: torch.Tensor, assigned_weights: torch.Tensor) -> torch.Tensor:
+        """Update the center of the search distribution m
+        With zs and ys retained from sampling, this operation is O(popsize d), as it involves summing across popsize d-dimensional vectors.
+        Args:
+            zs (torch.Tensor): A tensor of shape [popsize, d] of samples from the local coordinate space e.g. z_i ~ N(0, I_d)
+            ys (torch.Tensor): A tensor of shape [popsize, d] of samples from the shaped coordinate space e.g. y_i ~ N(0, C)
+            assigned_weights (torch.Tensor): A [popsize, ] dimensional tensor of ordered weights
+        Returns:
+            local_m_displacement (torch.Tensor): A tensor of shape [d], corresponding to the local transformation of m,
+                (1/sigma) (C^-1/2) (m' - m) where m' is the updated m
+            shaped_m_displacement (torch.Tensor): A tensor of shape [d], corresponding to the shaped transformation of m,
+                (1/sigma) (m' - m) where m' is the updated m
+        """
+        # Get the top-mu weights
+        top_mu = torch.topk(assigned_weights, k=self.mu)
+        top_mu_weights = top_mu.values
+        top_mu_indices = top_mu.indices
+
+        # Compute the weighted recombination in local coordinate space
+        local_m_displacement = torch.sum(top_mu_weights.unsqueeze(-1) * zs[top_mu_indices], dim=0)
+        # Compute the weighted recombination in shaped coordinate space
+        shaped_m_displacement = torch.sum(top_mu_weights.unsqueeze(-1) * ys[top_mu_indices], dim=0)
+
+        # Update m
+        self.m = self.m + self.c_m * self.sigma * shaped_m_displacement
+
+        # Return the weighted recombinations
+        return local_m_displacement, shaped_m_displacement
+
+    def update_p_sigma(self, local_m_displacement: torch.Tensor) -> None:
+        """Update the evolution path for sigma, p_sigma
+        This operation is bounded O(d), as is simply the sum of vectors
+        Args:
+            local_m_displacement (torch.Tensor): The weighted recombination of local samples zs, corresponding to
+                (1/sigma) (C^-1/2) (m' - m) where m' is the updated m
+        """
+        self.p_sigma = (1 - self.c_sigma) * self.p_sigma + self.variance_discount_sigma * local_m_displacement
+
+    def update_sigma(self) -> None:
+        """Update the step size sigma according to its evolution path p_sigma
+        This operation is bounded O(d), with the most expensive component being the norm of the evolution path, a d-dimensional vector.
+        """
+        d = self._problem.solution_length
+        # Compute the exponential update
+        if self.csa_squared:
+            # Exponential update based on natural gradient maximizing squared norm of p_sigma
+            exponential_update = (torch.norm(self.p_sigma).pow(2.0) / d - 1) / 2
+        else:
+            # Exponential update increasing likelihood p_sigma having expected norm
+            exponential_update = torch.norm(self.p_sigma) / self.unbiased_expectation - 1
+        # Rescale exponential update based on learning rate + damping factor
+        exponential_update = (self.c_sigma / self.damp_sigma) * exponential_update
+        # Multiplicative update to sigma
+        self.sigma = self.sigma * torch.exp(exponential_update)
+
+    def update_p_c(self, shaped_m_displacement: torch.Tensor, h_sig: torch.Tensor) -> None:
+        """Update the evolution path for rank-1 update, p_c
+        This operation is bounded O(d), as is simply the sum of vectors
+        Args:
+            local_m_displacement (torch.Tensor): The weighted recombination of shaped samples ys, corresponding to
+                (1/sigma) (m' - m) where m' is the updated m
+            h_sig (torch.Tensor): Whether to stall the update based on the evolution path on sigma, p_sigma, expressed as a torch float
+        """
+        self.p_c = (1 - self.c_c) * self.p_c + h_sig * self.variance_discount_c * shaped_m_displacement
+
+    def update_C(self, zs: torch.Tensor, ys: torch.Tensor, assigned_weights: torch.Tensor, h_sig: torch.Tensor) -> None:
+        """Update the covariance shape matrix C based on rank-1 and rank-mu updates
+        This operation is bounded O(d^2 popsize), which is associated with computing the rank-mu update (summing across popsize d*d matrices)
+        Args:
+            zs (torch.Tensor): A tensor of shape [popsize, d] of samples from the local coordinate space e.g. z_i ~ N(0, I_d)
+            ys (torch.Tensor): A tensor of shape [popsize, d] of samples from the shaped coordinate space e.g. y_i ~ N(0, C)
+            assigned_weights (torch.Tensor): A [popsize, ] dimensional tensor of ordered weights
+            h_sig (torch.Tensor): Whether to stall the update based on the evolution path on sigma, p_sigma, expressed as a torch float
+        """
+        d = self._problem.solution_length
+        # If using Active CMA-ES, reweight negative weights
+        if self.active:
+            assigned_weights = torch.where(
+                assigned_weights > 0, assigned_weights, d * assigned_weights / torch.norm(zs, dim=-1).pow(2.0)
+            )
+        c1a = self.c_1 * (1 - (1 - h_sig**2) * self.c_c * (2 - self.c_c))  # adjust for variance loss
+        weighted_pc = (self.c_1 / (c1a + 1e-23)) ** 0.5
+        if self.separable:
+            # Rank-1 update
+            r1_update = c1a * (self.p_c.pow(2.0) - self.C)
+            # Rank-mu update
+            rmu_update = self.c_mu * torch.sum(
+                assigned_weights.unsqueeze(-1) * (ys.pow(2.0) - self.C.unsqueeze(0)), dim=0
+            )
+        else:
+            # Rank-1 update
+            r1_update = c1a * (torch.outer(weighted_pc * self.p_c, weighted_pc * self.p_c) - self.C)
+            # Rank-mu update
+            rmu_update = self.c_mu * (
+                torch.sum(assigned_weights.unsqueeze(-1).unsqueeze(-1) * (ys.unsqueeze(1) * ys.unsqueeze(2)), dim=0)
+                - torch.sum(self.weights) * self.C
+            )
+
+        # Update C
+        self.C = self.C + r1_update + rmu_update
+
+    def decompose_C(self) -> None:
+        """Perform the decomposition C = AA^T using a cholesky decomposition
+        Note that traditionally CMA-ES uses the eigendecomposition C = BDDB^-1. In our case,
+        we keep track of zs, ys and xs when sampling, so we never need C^-1/2.
+        Therefore, a cholesky decomposition is all that is necessary. This generally requires
+        O(d^3/3) operations, rather than the more costly O(d^3) operations associated with the eigendecomposition.
+        """
+        if self.separable:
+            self.A = self.C.pow(0.5)
+        else:
+            self.A = torch.linalg.cholesky(self.C)
+
+    def _step(self):
+        """Perform a step of the CMA-ES solver"""
+
+        # === Sampling, evaluation and ranking ===
+
+        # Sample the search distribution
+        zs, ys, xs = self.sample_distribution()
+        # Get the weights assigned to each solution
+        assigned_weights = self.get_population_weights(xs)
+
+        # === Center adaption ===
+
+        local_m_displacement, shaped_m_displacement = self.update_m(zs, ys, assigned_weights)
+
+        # === Step size adaption ===
+
+        # Update evolution path p_sigma
+        self.update_p_sigma(local_m_displacement)
+        # Update sigma
+        self.update_sigma()
+
+        # Compute h_sig, a boolean flag for stalling the update to p_c
+        h_sig = _h_sig(self.p_sigma, self.c_sigma, self._steps_count)
+
+        # === Unscaled covariance adapation ===
+
+        # Update evolution path p_c
+        self.update_p_c(shaped_m_displacement, h_sig)
+        # Update the covariance shape C
+        self.update_C(zs, ys, assigned_weights, h_sig)
+
+        # === Post-step corrections ===
+
+        # Limit element-wise standard deviation of sigma^2 C
+        if self.stdev_min is not None or self.stdev_max is not None:
+            self.C = _limit_stdev(self.sigma, self.C, self.stdev_min, self.stdev_max)
+
+        # Decompose C
+        if (self._steps_count + 1) % self.decompose_C_freq == 0:
+            self.decompose_C()

--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -106,7 +106,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         self,
         problem: Problem,
         *,
-        stepsize_init: Real,
+        stdev_init: Real,
         popsize: Optional[int] = None,
         center_init: Optional[Vector] = None,
         c_m: Real = 1.0,
@@ -133,7 +133,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
 
         Args:
             problem (Problem): The problem object which is being worked on.
-            stepsize_init (Real): Initial step-size
+            stdev_init (Real): Initial step-size
             popsize: Population size. Can be specified as an int,
                 or can be left as None in which case the CMA-ES rule of thumb is applied:
                 popsize = 4 + floor(3 log d) where d is the dimension
@@ -240,7 +240,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         self.m = self._problem.make_tensor(center_init)
 
         # Store the initial step size
-        self.sigma = self._problem.make_tensor(stepsize_init)
+        self.sigma = self._problem.make_tensor(stdev_init)
 
         if separable:
             # Initialize C as the diagonal vector. Note that when separable, the eigendecomposition is not needed

--- a/src/evotorch/algorithms/pycmaes.py
+++ b/src/evotorch/algorithms/pycmaes.py
@@ -1,0 +1,286 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa: C901
+
+"""
+This namespace contains the PyCMAES class, which is a wrapper
+for the CMA-ES implementation of the `cma` package.
+"""
+
+import math
+from copy import copy, deepcopy
+from typing import Any, Callable, Iterable, List, Optional, Union
+
+import numpy as np
+import torch
+
+from ..core import Problem, SolutionBatch
+from ..tools.misc import Device, DType, RealOrVector, Vector, is_sequence, numpy_copy
+from .searchalgorithm import SearchAlgorithm, SinglePopulationAlgorithmMixin
+
+try:
+    import cma
+except ImportError:
+    cma = None
+
+
+class PyCMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
+    """
+    PyCMAES: Covariance Matrix Adaptation Evolution Strategy.
+
+    This is an interface class between the CMAES implementation
+    within the `cma` package developed within the GitHub repository
+    CMA-ES/pycma.
+
+    References:
+
+        Nikolaus Hansen, Youhei Akimoto, and Petr Baudis.
+        CMA-ES/pycma on Github. Zenodo, DOI:10.5281/zenodo.2559634,
+        February 2019.
+        <https://github.com/CMA-ES/pycma>
+
+        Nikolaus Hansen, Andreas Ostermeier (2001).
+        Completely Derandomized Self-Adaptation in Evolution Strategies.
+
+    """
+
+    def __init__(
+        self,
+        problem: Problem,
+        *,
+        stdev_init: RealOrVector,  # sigma0
+        popsize: Optional[int] = None,  # popsize
+        center_init: Optional[Vector] = None,  # x0
+        center_learning_rate: Optional[float] = None,  # CMA_cmean
+        cov_learning_rate: Optional[float] = None,  # CMA_on
+        rankmu_learning_rate: Optional[float] = None,  # CMA_rankmu
+        rankone_learning_rate: Optional[float] = None,  # CMA_rankone
+        stdev_min: Optional[Union[float, np.ndarray]] = None,  # minstd
+        stdev_max: Optional[Union[float, np.ndarray]] = None,  # maxstd
+        separable: bool = False,  # CMA_diagonal
+        obj_index: Optional[int] = None,
+        cma_options: dict = {},
+    ):
+        """
+        `__init__(...)`: Initialize the PyCMAES solver.
+
+        Args:
+            problem: The problem object which is being worked on.
+            stdev_init: Initial standard deviation as a scalar or
+                as a 1-dimensional array.
+            popsize: Population size. Can be specified as an int,
+                or can be left as None to let the CMAES solver
+                decide the population size according to the length
+                of a solution.
+            center_init: Initial center point of the search distribution.
+                Can be given as a SolutionVector or as a 1-D array.
+                If left as None, an initial center point is generated
+                with the help of the problem object's `generate_values(...)`
+                method.
+            center_learning_rate: Learning rate for updating the mean
+                of the search distribution. Leaving this as None
+                means that the CMAES solver is to use its own default,
+                which is documented as 1.0.
+            cov_learning_rate: Learning rate for updating the covariance
+                matrix of the search distribution. This hyperparameter
+                acts as a common multiplier for rank_one update and rank_mu
+                update of the covariance matrix. Leaving this as None
+                means that the CMAES solver is to use its own default,
+                which is documented as 1.0.
+            rankmu_learning_rate: Learning rate for the rank_mu update
+                of the covariance matrix of the search distribution.
+                Leaving this as None means that the CMAES solver is to use
+                its own default, which is documented as 1.0.
+            rankone_learning_rate: Learning rate for the rank_one update
+                of the covariance matrix of the search distribution.
+                Leaving this as None means that the CMAES solver is to use
+                its own default, which is documented as 1.0.
+            stdev_min: Minimum allowed standard deviation of the search
+                distribution. Leaving this as None means that no such
+                boundary is to be used.
+                Can be given as None, as a scalar, or as a 1-dimensional
+                array.
+            stdev_max: Maximum allowed standard deviation of the search
+                distribution. Leaving this as None means that no such
+                boundary is to be used.
+                Can be given as None, as a scalar, or as a 1-dimensional
+                array.
+            separable: Provide this as True if you would like the problem
+                to be treated as a separable one. Treating a problem
+                as separable means to adapt only the diagonal parts
+                of the covariance matrix and to keep the non-diagonal
+                parts 0. High dimensional problems result in large
+                covariance matrices on which operating is computationally
+                expensive. Therefore, for such high dimensional problems,
+                setting `separable` as True might be useful.
+                If, instead, you would like to configure on which
+                iterations the diagonal parts of the covariance matrix
+                are to be adapted, then it is recommended to leave
+                `separable` as False and set a new value for the key
+                "CMA_diagonal" via `cma_options` (see the official
+                documentation of pycma for details regarding the
+                "CMA_diagonal" setting).
+            obj_index: Objective index according to which evaluation
+                of the solution will be done.
+            cma_options: Any other configuration for the CMAES solver
+                can be passed via the cma_options dictionary.
+        """
+
+        # Make sure that the cma module is installed
+        if cma is None:
+            raise ImportError(f"The class {type(self).__name__} is only available if the package `cma` is installed.")
+
+        # Initialize the base class
+        SearchAlgorithm.__init__(self, problem, center=self._get_center)
+
+        # Ensure that the problem is numeric
+        problem.ensure_numeric()
+
+        # Store the objective index
+        self._obj_index = problem.normalize_obj_index(obj_index)
+
+        # If `center_init` is not given, generate an initial solution
+        # with the help of the problem object.
+        # Otherwise, use the given initial solution as the starting
+        # point in the search space.
+        if center_init is None:
+            x0 = self._problem.generate_values(1).to("cpu").view(-1).numpy().astype(dtype=float)
+        else:
+            x0 = numpy_copy(center_init, dtype=float)
+
+        # Store the initial standard deviations
+        sigma0 = numpy_copy(stdev_init, dtype=float)
+
+        # Generate an options dictionary to pass to the cma solver.
+        inopts = {}
+        for k, v in cma_options.items():
+            if isinstance(v, torch.Tensor):
+                v = numpy_copy(v, dtype=float)
+            inopts[k] = v
+
+        # Remove the number of iterations boundary
+        if "maxiter" not in inopts:
+            inopts["maxiter"] = np.inf
+
+        # Below is a temporary helper function for safely storing the configuration items.
+        # This inner function updates the `inopts` variable.
+        def store_opt(key: str, long_name: str, value: Any, converter: Callable):
+            # Here, `key` represents the configuration key used by pycma
+            # `long_name` represents the configuration's long name used by this class
+            # `value` is the configuration value associated with `key`.
+
+            # Declare that this inner function accesses the `inopts` variable.
+            nonlocal inopts
+
+            if value is None:
+                # If the provided `value` is None, then there is no configuration to store.
+                # So, we just leave this inner function.
+                return
+
+            if key in inopts:
+                # If the given `key` already exists within `inopts`, this means that the configuration was specified
+                # twice: via the keyword argument `cma_options` AND via a keyword argument.
+                # We raise an error and inform the user about this redundancy.
+                raise ValueError(
+                    f"The configuration {repr(key)} was redundantly provided"
+                    f" both via the initialization argument {long_name}"
+                    f" and via the cma_options dictionary."
+                    f" {long_name}={repr(value)};"
+                    f" cma_options[{repr(key)}]={repr(inopts[key])}."
+                )
+
+            inopts[key] = converter(value)
+
+        # Temporary helper function which makes sure that `x` is a numpy array or a float.
+        def array_or_float(x):
+            if is_sequence(x):
+                return numpy_copy(x)
+            else:
+                return float(x)
+
+        # Store the cma configuration received through the initialization arguments (and raise error if there is
+        # redundancy with the cma_options dictionary).
+        store_opt("popsize", "popsize", popsize, int)
+        store_opt("CMA_cmean", "center_learning_rate", center_learning_rate, float)
+        store_opt("CMA_on", "cov_learning_rate", cov_learning_rate, float)
+        store_opt("CMA_rankmu", "rankmu_learning_rate", rankmu_learning_rate, float)
+        store_opt("CMA_rankone", "rankone_learning_rate", rankone_learning_rate, float)
+        store_opt("minstd", "stdev_min", stdev_min, array_or_float)
+        store_opt("maxstd", "stdev_max", stdev_max, array_or_float)
+        if separable:
+            store_opt("CMA_diagonal", "separable", separable, bool)
+
+        # If the problem defines lower and upper bounds, pass these into the options dict.
+        def process_bounds(bounds: RealOrVector) -> np.ndarray:
+            if bounds is None:
+                return None
+            else:
+                if is_sequence(bounds):
+                    bounds = numpy_copy(bounds)
+                else:
+                    bounds = np.array(float(bounds)).repeat(self._problem.solution_length)
+                return bounds
+
+        lb = process_bounds(self._problem.lower_bounds)
+        ub = process_bounds(self._problem.upper_bounds)
+
+        register_bounds = False
+        if lb is not None and ub is None:
+            ub = np.array(np.inf).repeat(self._problem.solution_length)
+            register_bounds = True
+        elif lb is None and ub is not None:
+            lb = np.array(-(np.inf)).repeat(self._problem.solution_length)
+            register_bounds = True
+        elif lb is not None and ub is not None:
+            register_bounds = True
+
+        if register_bounds:
+            inopts["bounds"] = [lb, ub]
+
+        # Generate a random seed using the problem object for the sake of reproducibility.
+        if "seed" not in inopts:
+            inopts["seed"] = int(self._problem.make_randint(tuple(), n=(2**32) - 100) + 100)
+
+        # Instantiate the CMAEvolutionStrategy with the prepared configuration items.
+        self._es = cma.CMAEvolutionStrategy(x0, sigma0, inopts)
+
+        # Initialize the population.
+        self._population: SolutionBatch = self._problem.generate_batch(self._es.popsize, empty=True)
+
+        # Use the SinglePopulationAlgorithmMixin to enable additional status reports regarding the population.
+        SinglePopulationAlgorithmMixin.__init__(self)
+
+    @property
+    def population(self) -> SolutionBatch:
+        """Population generated by the CMA-ES algorithm"""
+        return self._population
+
+    def _step(self):
+        """Perform a step of the CMA-ES solver"""
+        asked = self._es.ask()
+        self._population.access_values()[:] = torch.as_tensor(
+            np.asarray(asked), dtype=self._problem.dtype, device=self._population.device
+        )
+        self._problem.evaluate(self._population)
+        scores = numpy_copy(self._population.utility(self._obj_index), dtype=float)
+        self._es.tell(asked, -1.0 * scores)
+
+    def _get_center(self) -> torch.Tensor:
+        return torch.as_tensor(self._es.result[5], dtype=self._population.dtype, device=self._population.device)
+
+    @property
+    def obj_index(self) -> int:
+        """Index of the objective being focused on"""
+        return self._obj_index

--- a/src/evotorch/algorithms/restarter/__init__.py
+++ b/src/evotorch/algorithms/restarter/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This namespace contains the implementations of various
+restart mechanisms
+"""
+
+__all__ = (
+    "Restart",
+    "ModifyingRestart",
+    "IPOP",
+)
+
+
+from . import modify_restart, restart
+from .modify_restart import IPOP, ModifyingRestart
+from .restart import Restart

--- a/src/evotorch/algorithms/restarter/modify_restart.py
+++ b/src/evotorch/algorithms/restarter/modify_restart.py
@@ -1,0 +1,72 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+from typing import Type
+
+from .restart import Restart
+from evotorch import Problem
+from evotorch.algorithms import SearchAlgorithm
+
+
+class ModifyingRestart(Restart):
+    def _modify_algorithm_args(self) -> None:
+        """Modify the algorithm arguments on restart"""
+        pass
+
+    def _restart(self) -> None:
+        """Restart the search algorithm"""
+        self._modify_algorithm_args()
+        return super()._restart()
+
+
+class IPOP(ModifyingRestart):
+    def __init__(
+        self,
+        problem: Problem,
+        algorithm_class: Type[SearchAlgorithm],
+        algorithm_args: dict = {},
+        min_fitness_stdev: float = 1e-9,
+        popsize_multiplier: float = 2,
+    ):
+        """IPOP restart, terminates algorithm when minimum standard deviation in fitness values is hit, multiplies the population size in that case
+        References:
+            Glasmachers, Tobias, and Oswin Krause.
+            "The hessian estimation evolution strategy."
+            PPSN 2020
+        Args:
+            problem (Problem): A Problem to solve
+            algorithm_class (Type[SearchAlgorithm]): The class of the search algorithm to restart
+            algorithm_args (dict): Arguments to pass to the search algorithm on restart
+            min_fitness_stdev (float): The minimum standard deviation in fitnesses; going below this will trigger a restart
+            popsize_multiplier (float): A multiplier on the population size within algorithm_args
+        """
+        super().__init__(problem, algorithm_class, algorithm_args)
+
+        self.min_fitness_stdev = min_fitness_stdev
+        self.popsize_multiplier = popsize_multiplier
+
+    def _search_algorithm_terminated(self) -> bool:
+        # Additional check on standard deviation of fitnesses of population
+        if self.search_algorithm.population.evals.std() < self.min_fitness_stdev:
+            return True
+        return super()._search_algorithm_terminated()
+
+    def _modify_algorithm_args(self) -> None:
+        # Only modify arguments if this isn't the first restart
+        if self.num_restarts >= 1:
+            new_args = deepcopy(self._algorithm_args)
+            # Multiply population size
+            new_args["popsize"] = int(self.popsize_multiplier * len(self.search_algorithm.population))
+            self._algorithm_args = new_args

--- a/src/evotorch/algorithms/restarter/restart.py
+++ b/src/evotorch/algorithms/restarter/restart.py
@@ -1,0 +1,75 @@
+# Copyright 2022 NNAISENSE SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Type
+
+from evotorch import Problem
+from evotorch.algorithms.searchalgorithm import SearchAlgorithm
+
+
+class Restart(SearchAlgorithm):
+    def __init__(
+        self,
+        problem: Problem,
+        algorithm_class: Type[SearchAlgorithm],
+        algorithm_args: dict = {},
+        **kwargs: Any,
+    ):
+        """Base class for independent restarts methods
+        Args:
+            problem (Problem): A Problem to solve
+            algorithm_class (Type[SearchAlgorithm]): The class of the search algorithm to restart
+            algorithm_args (dict): Arguments to pass to the search algorithm on restart
+        """
+
+        SearchAlgorithm.__init__(
+            self,
+            problem,
+            search_algorithm=self._get_sa_status,
+            num_restarts=self._get_num_restarts,
+            algorithm_terminated=self._search_algorithm_terminated,
+            **kwargs,
+        )
+
+        self._algorithm_class = algorithm_class
+        self._algorithm_args = algorithm_args
+
+        self.num_restarts = 0
+        self._restart()
+
+    def _get_sa_status(self) -> dict:
+        """Status dictionary of search algorithm"""
+        return self.search_algorithm.status
+
+    def _get_num_restarts(self) -> int:
+        """Number of restarts (including the first start) so far"""
+        return self.num_restarts
+
+    def _restart(self) -> None:
+        """Restart the search algorithm"""
+        self.search_algorithm = self._algorithm_class(self._problem, **self._algorithm_args)
+        self.num_restarts += 1
+
+    def _search_algorithm_terminated(self) -> bool:
+        """Boolean flag for search algorithm terminated"""
+        return self.search_algorithm.is_terminated
+
+    def _step(self):
+
+        # Step the search algorithm
+        self.search_algorithm.step()
+
+        # If stepping the search algorithm has reached a terminal state, restart the search algorithm
+        if self._search_algorithm_terminated():
+            self._restart()

--- a/src/evotorch/algorithms/searchalgorithm.py
+++ b/src/evotorch/algorithms/searchalgorithm.py
@@ -441,6 +441,11 @@ class SearchAlgorithm(LazyReporter):
         """
         self._first_step_datetime = None
 
+    @property
+    def is_terminated(self) -> bool:
+        """Whether the algorithm is in a terminal state"""
+        return False
+
 
 class SinglePopulationAlgorithmMixin:
     """


### PR DESCRIPTION
This pull request:
- Refactors the existing `evotorch.algorithms.cmaes.CMAES`, which is simply a wrapper for [pycma](https://github.com/CMA-ES/pycma/tree/master/cma) to `evotorch.algorithms.pycmaes.PyCMAES`.
- Introduces a new, torch-based, implementation of CMAES under the name `evotorch.algorithms.cmaes.CMAES`. This aims to faithfully reimplement the most recent version of pycma, while also benefiting from the evotorch ecosystem e.g. vectorized, GPU based, working with torch tensors for compatibility with other features. 
- Introduces `evotorch.algorithms.restarters`, which provides basic functionality for meta-algorithms that wrap around a `SearchAlgorithm` class + parameterization, and allow automatic restarting of the algorithm. This creates basic functionality for the eventual re-implementation e.g. of IPOP-CMA-ES and BIPOP-CMA-ES, and equivalent algorithms for XNES, SNES etc.
- Adds the `is_terminated` flag to all `SearchAlgorithm` classes, that will allow the user to define their own general functionality for detecting termination states that should trigger restarts. Currently, this value defaults to `False`, but in the future it is intended to add example termination states to the new `CMAES` implementation. 