### PR TITLE
feat: Add env. variable to control verbosity of the logger

### DIFF
--- a/src/evotorch/__init__.py
+++ b/src/evotorch/__init__.py
@@ -41,15 +41,16 @@ from . import algorithms, decorators, distributions, logging, neuroevolution, op
 
 _env_verbose_level = str(os.getenv("EVOTORCH_VERBOSE_LEVEL", "1"))
 _verbose_level = {
+    "-1": -1,
     "0": _py_logging.WARNING,
     "1": _py_logging.INFO,
     "2": _py_logging.DEBUG,
 }.get(_env_verbose_level)
 
-if _verbose_level:
-    tools.misc.set_default_logger_config(logger_level=_verbose_level)
-else:
+if _verbose_level is None:
     _py_logging.getLogger("evotorch").warning(f"Unknown value passed to EVOTORCH_VERBOSE_LEVEL ({_env_verbose_level}).")
+elif _verbose_level >= 0:
+    tools.misc.set_default_logger_config(logger_level=_verbose_level)
 
 __all__ = (
     "__version__",

--- a/src/evotorch/__init__.py
+++ b/src/evotorch/__init__.py
@@ -33,7 +33,7 @@ from .core import Problem, Solution, SolutionBatch
 
 # isort: on
 
-import logging
+import logging as _py_logging
 
 from . import algorithms, decorators, distributions, logging, neuroevolution, optimizers, testing
 
@@ -41,15 +41,15 @@ from . import algorithms, decorators, distributions, logging, neuroevolution, op
 
 _env_verbose_level = str(os.getenv("EVOTORCH_VERBOSE_LEVEL", "1"))
 _verbose_level = {
-    "0": logging.WARNING,
-    "1": logging.INFO,
-    "2": logging.DEBUG,
+    "0": _py_logging.WARNING,
+    "1": _py_logging.INFO,
+    "2": _py_logging.DEBUG,
 }.get(_env_verbose_level)
 
 if _verbose_level:
     tools.misc.set_default_logger_config(logger_level=_verbose_level)
 else:
-    logging.getLogger("evotorch").warning(f"Unknown value passed to EVOTORCH_VERBOSE_LEVEL ({_env_verbose_level}).")
+    _py_logging.getLogger("evotorch").warning(f"Unknown value passed to EVOTORCH_VERBOSE_LEVEL ({_env_verbose_level}).")
 
 __all__ = (
     "__version__",

--- a/src/evotorch/__init__.py
+++ b/src/evotorch/__init__.py
@@ -33,7 +33,23 @@ from .core import Problem, Solution, SolutionBatch
 
 # isort: on
 
+import logging
+
 from . import algorithms, decorators, distributions, logging, neuroevolution, optimizers, testing
+
+# Set verbosity level of EvoTorch
+
+_env_verbose_level = str(os.getenv("EVOTORCH_VERBOSE_LEVEL", "1"))
+_verbose_level = {
+    "0": logging.WARNING,
+    "1": logging.INFO,
+    "2": logging.DEBUG,
+}.get(_env_verbose_level)
+
+if _verbose_level:
+    tools.misc.set_default_logger_config(logger_level=_verbose_level)
+else:
+    logging.getLogger("evotorch").warning(f"Unknown value passed to EVOTORCH_VERBOSE_LEVEL ({_env_verbose_level}).")
 
 __all__ = (
     "__version__",

--- a/src/evotorch/tools/misc.py
+++ b/src/evotorch/tools/misc.py
@@ -1973,6 +1973,7 @@ def set_default_logger_config(
             logger.removeHandler(handler)
 
     logger.setLevel(logger_level)
+    logger.propagate = False
 
     formatter = logging.Formatter(
         "[{asctime}] "


### PR DESCRIPTION
This PR adds an env. variable `EVOTORCH_VERBOSE_LEVEL` to control the default verbosity of the EvoTorch Logger.

Supported values and their logging levels counterparts are:
- `0` sets `logging.WARNING`
- `1` sets `logging.INFO` (**default**)
- `2` sets `logging.DEBUG`

## TODO
- [ ]  Add docs