### PR TITLE
Fix the interface of `make_I`

### DIFF
--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -253,7 +253,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
             self.A = self._problem.make_ones(d)
         else:
             # Initialize C = AA^T all diagonal.
-            self.C = torch.eye(d, dtype=problem.dtype, device=problem.device)
+            self.C = self.problem.make_I(d)
             self.A = self.C.clone()
 
         # === Initialize raw weights ===

--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -253,7 +253,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
             self.A = self._problem.make_ones(d)
         else:
             # Initialize C = AA^T all diagonal.
-            self.C = self.problem.make_I(d)
+            self.C = self._problem.make_I(d)
             self.A = self.C.clone()
 
         # === Initialize raw weights ===

--- a/src/evotorch/distributions.py
+++ b/src/evotorch/distributions.py
@@ -724,8 +724,7 @@ class ExpGaussian(Distribution):
             dtype=dtype,
         )
         # Make identity matrix as this is used throughout in gradient computation
-        self.eye = self.make_zeros((solution_length, solution_length))
-        self.eye[range(self.solution_length), range(self.solution_length)] = 1.0
+        self.eye = self.make_I(solution_length)
 
     @property
     def mu(self) -> torch.Tensor:

--- a/src/evotorch/tools/misc.py
+++ b/src/evotorch/tools/misc.py
@@ -1342,6 +1342,7 @@ def make_nan(
 
 def make_I(
     size: Optional[int] = None,
+    *,
     out: Optional[torch.Tensor] = None,
     dtype: Optional[DType] = None,
     device: Optional[Device] = None,
@@ -1359,7 +1360,8 @@ def make_I(
         make_I(out=existing_tensor)
 
     Args:
-        size: A single integer specifying the length of the target square
+        size: A single integer or a tuple containing a single integer,
+            where the integer specifies the length of the target square
             matrix. In this context, "length" means both rowwise length
             and columnwise length, since the target is a square matrix.
             Note that, if the user wishes to fill an existing tensor with
@@ -1383,11 +1385,20 @@ def make_I(
     if size is None:
         if out is None:
             raise ValueError(
-                " When the `size` argument is missing, `make_I(...)` expects an `out` tensor."
+                "When the `size` argument is missing, the function `make_I(...)` expects an `out` tensor."
                 " However, the `out` argument was received as None."
             )
         size = tuple()
     else:
+        if isinstance(size, tuple):
+            if len(size) == 1:
+                size = size[0]
+            else:
+                raise ValueError(
+                    f"When the `size` argument is given as a tuple,"
+                    f" the function `make_I(...)` expects this tuple to contain exactly one element."
+                    f" The received tuple is {size}."
+                )
         n = int(size)
         size = (n, n)
     out = _out_tensor(*size, out=out, dtype=dtype, device=device)


### PR DESCRIPTION
The function `evotorch.tools.make_I` was accepting a single integer as the size indicator of the identity matrix. However, the method `Problem.make_I` was working only when the size was given as a single-element tuple. This pull request makes their interfaces compatible by making isure that both will work with a single integer or with a size tuple containing a single integer. Tests are updated to verify the correctness of the revised interfaces.