### PR TITLE
fix: `generate_batch` returning `None`

### DIFF
--- a/src/evotorch/core.py
+++ b/src/evotorch/core.py
@@ -1802,6 +1802,7 @@ class Problem(TensorMakerMixin, Serializable):
                 )
             result = SolutionBatch(self, popsize, device=self.device, empty=True)
             self.make_gaussian(out=result.access_values(), center=center, stdev=stdev, symmetric=symmetric)
+            return result
         else:
             raise ValueError(
                 f"The arguments `center` and `stdev` were expected to be None or non-None at the same time."


### PR DESCRIPTION
The method `Problem.generate_batch(...)` was unexpectedly returning `None` when the keyword arguments `center` and `stdev` are provided. The reason for this erroneous behavior was a missing `return` statement in the code. This pull request fixes the issue by introducing the forgotten `return` statement.