### PR TITLE
Fix C decomposition rate calculation on CUDA devices

### DIFF
--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -362,7 +362,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
 
         # How often to decompose C
         if limit_C_decomposition:
-            self.decompose_C_freq = max(1, int(1 / np.floor(10 * d * (self.c_1 + self.c_mu))))
+            self.decompose_C_freq = max(1, int(1 / np.floor(10 * d * (self.c_1.cpu() + self.c_mu.cpu()))))
         else:
             self.decompose_C_freq = 1
 
@@ -380,7 +380,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
 
     def _get_sigma(self) -> torch.Tensor:
         """Get the step-size of the search distribution, sigma"""
-        return self.sigma
+        return float(self.sigma.cpu())
 
     @property
     def obj_index(self) -> int:

--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -378,7 +378,7 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         """Get the center of search distribution, m"""
         return self.m
 
-    def _get_sigma(self) -> torch.Tensor:
+    def _get_sigma(self) -> float:
         """Get the step-size of the search distribution, sigma"""
         return float(self.sigma.cpu())
 


### PR DESCRIPTION
This PR resolves #61 by ensuring the decomposition rate of C is calculated using values on the CPU. It also ensures that the step size is reported as a float, regardless of the `dtype` and `device` of the problem. This is important as step size is a single value and is therefore reported like e.g. `mean_eval`. 