### PR TITLE
Fix CMAES._get_sigma

### DIFF
--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -387,9 +387,9 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
         """Get the center of search distribution, m"""
         return self.m
 
-    def _get_sigma(self) -> float:
+    def _get_sigma(self) -> torch.Tensor:
         """Get the step-size of the search distribution, sigma"""
-        return float(self.sigma.cpu())
+        return self.sigma.to(device="cpu", dtype=torch.float)
 
     @property
     def obj_index(self) -> int:


### PR DESCRIPTION
See issue #101

Do not cast sigma to a builtin float but keep it as a torch.Tensor. Now the return type also matches with the superclass.