### PR TITLE
Update vectorized reinforcement learning

### DIFF
--- a/examples/notebooks/Brax_Experiments_with_PGPE.ipynb
+++ b/examples/notebooks/Brax_Experiments_with_PGPE.ipynb
@@ -37,7 +37,11 @@
     "\n",
     "import os\n",
     "import torch\n",
-    "from torch import nn"
+    "from torch import nn\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from glob import glob\n",
+    "import shutil"
    ]
   },
   {
@@ -51,32 +55,94 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8fb0cb8e-c247-4416-94cd-9a8349192421",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def how_many_cuda_devices():\n",
+    "    import sys\n",
+    "    import subprocess as sp\n",
+    "\n",
+    "    instr = r\"\"\"\n",
+    "import torch\n",
+    "x = torch.as_tensor(1.0)\n",
+    "device_count = 0\n",
+    "while True:\n",
+    "    try:\n",
+    "        x.to(f\"cuda:{device_count}\")\n",
+    "        device_count += 1\n",
+    "    except Exception:\n",
+    "        break\n",
+    "print(device_count)\"\"\"\n",
+    "\n",
+    "    proc = sp.Popen([\"python\"], stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, text=True)\n",
+    "    outstr, errstr = proc.communicate(instr)\n",
+    "    rcode = proc.wait()\n",
+    "    if rcode == 0:\n",
+    "        return int(outstr.strip())\n",
+    "    else:\n",
+    "        print(errstr)\n",
+    "        raise RuntimeError(f\"Cannot determine number of cuda devices:\\n\\n{errstr}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef60c766-d03a-4c37-8966-1db77d7658f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_CUDA_DEVICES = how_many_cuda_devices()\n",
+    "print(\"We have\", NUM_CUDA_DEVICES, \"CUDA devices\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "d45edbf5-b0e9-43a0-869a-5146321ddd4e",
    "metadata": {},
    "outputs": [],
    "source": [
     "if torch.cuda.is_available():\n",
+    "    assert NUM_CUDA_DEVICES >= 1\n",
     "    # CUDA is available. Here, we prepare GPU-specific settings.\n",
-    "    \n",
-    "    # We tell XLA (the backend of JAX) to use half of a GPU.\n",
-    "    os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \".5\"\n",
-    "    \n",
-    "    # We make only one GPU visible.\n",
-    "    os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
-    "    \n",
-    "    # This is the device on which the population will be stored\n",
-    "    device = \"cuda:0\"\n",
-    "    \n",
-    "    # We do not want multi-actor parallelization.\n",
-    "    # For most basic brax tasks, it is enough to use a single GPU both\n",
-    "    # for the population and for the solution evaluations.\n",
-    "    num_actors = 0\n",
+    "\n",
+    "    if NUM_CUDA_DEVICES == 1:\n",
+    "        # We make only one GPU visible.\n",
+    "        os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
+    "\n",
+    "        # os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \".5\" # Tell JAX to pre-allocate half of a GPU\n",
+    "        os.environ[\"XLA_PYTHON_CLIENT_PREALLOCATE\"] = \"false\"  # Tell JAX to allocate on demand\n",
+    "        \n",
+    "        # This is the device on which the population will be stored\n",
+    "        device = \"cuda:0\"\n",
+    "        \n",
+    "        # We do not want multi-actor parallelization when we have only 1 GPU.\n",
+    "        num_actors = 0\n",
+    "\n",
+    "        # In the case of 1 CUDA device, there will be no distributed training\n",
+    "        num_gpus_per_actor = None\n",
+    "        distributed_algorithm = False\n",
+    "    else:\n",
+    "        # In the case of more than one CUDA devices, we enable distributed training\n",
+    "\n",
+    "        # os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = str((1 / NUM_CUDA_DEVICES) / 2)\n",
+    "        os.environ[\"XLA_PYTHON_CLIENT_PREALLOCATE\"] = \"false\"  # Tell JAX to allocate on demand\n",
+    "\n",
+    "        device = \"cpu\"  # Main device of the population is cpu\n",
+    "        num_actors = NUM_CUDA_DEVICES  # Allocate an actor per GPU\n",
+    "        num_gpus_per_actor = 1  # Each actor gets assigned a GPU\n",
+    "        distributed_algorithm = True  # PGPE is to work on distributed mode\n",
     "else:\n",
     "    # Since CUDA is not available, the device of the population will be cpu.\n",
     "    device = \"cpu\"\n",
-    "    \n",
-    "    # Use all the CPUs to speed-up the evaluations.\n",
-    "    num_actors = \"max\"\n",
+    "\n",
+    "    # No actor per GPU, since GPU is not available\n",
+    "    num_gpus_per_actor = None\n",
+    "    distributed_algorithm = False\n",
+    "\n",
+    "    #num_actors = \"max\"  # Use all the CPUs to speed-up the evaluations.\n",
+    "    num_actors = 1\n",
     "    \n",
     "    # Because we are already using all the CPUs for actor-based parallelization,\n",
     "    # we tell XLA not to use multiple threads for its operations.\n",
@@ -171,15 +237,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "94921740-188b-4b57-84a2-d5fab5b04a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TASK_NAME = \"brax::humanoid\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b502af4e-ff98-4483-af4b-6109ac768d36",
+   "metadata": {},
+   "source": [
+    "**Note.**\n",
+    "At the time of writing this (27 May 2024), the [arXiv paper of EvoTorch](https://arxiv.org/abs/2302.12600v3) reports results based on the old implementations of the brax tasks (which were the default until brax v0.1.2). In brax version v0.9.0, these old task implementations moved into the namespace `brax.v1`. If you wish to reproduce the results reported in the arXiv paper of EvoTorch, you might want to specify the environment name as `\"brax::old::humanoid\"` (where the substring `\"old::\"` causes `VecGymNE` to instantiate the environment using the namespace `brax.v1`), so that you will observe scores and execution times compatible with the ones reported in that arXiv paper. Please also see the mentioned arXiv paper for the hyperparameters used for the old brax environments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "56b5f554-cdec-40a5-8e21-fa09ea53e047",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ENV_NAME = \"brax::humanoid\"  # solve the brax task named \"humanoid\"\n",
-    "# ENV_NAME = \"brax::old::humanoid\"  # solve the \"humanoid\" task defined within 'brax.v1`\n",
-    "\n",
     "problem = VecGymNE(\n",
-    "    env=ENV_NAME,\n",
+    "    env=TASK_NAME,\n",
     "    network=policy,\n",
     "    #\n",
     "    # Collect observation stats, and use those stats to normalize incoming observations\n",
@@ -200,22 +282,10 @@
     "    alive_bonus_schedule=(400, 700, 10.0),\n",
     "    device=device,\n",
     "    num_actors=num_actors,\n",
+    "    num_gpus_per_actor=num_gpus_per_actor,\n",
     ")\n",
     "\n",
     "problem, problem.solution_length"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bce02d7c-400c-4c22-9bb8-aa70fa4b1da2",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "**Note.**\n",
-    "At the time of writing this (15 June 2023), the [arXiv paper of EvoTorch](https://arxiv.org/abs/2302.12600v3) reports results based on the old implementations of the brax tasks (which were the default until brax v0.1.2). In brax version v0.9.0, these old task implementations moved into the namespace `brax.v1`. If you wish to reproduce the results reported in the arXiv paper of EvoTorch, you might want to specify the environment name as `\"brax::old::humanoid\"` (where the substring `\"old::\"` causes `VecGymNE` to instantiate the environment using the namespace `brax.v1`), so that you will observe scores and execution times compatible with the ones reported in that arXiv paper.\n",
-    "\n",
-    "---"
    ]
   },
   {
@@ -241,18 +311,37 @@
     "MAX_SPEED = RADIUS / 6\n",
     "CENTER_LR = MAX_SPEED / 2\n",
     "\n",
+    "POPSIZE = 4000\n",
+    "NUM_GENERATIONS = 140\n",
+    "SAVE_INTERVAL = 20\n",
+    "\n",
     "# Instantiate a PGPE using the hyperparameters prepared above\n",
     "searcher = PGPE(\n",
     "    problem,\n",
-    "    popsize=12000,\n",
+    "    popsize=POPSIZE,\n",
     "    radius_init=RADIUS,\n",
     "    center_learning_rate=CENTER_LR,\n",
     "    optimizer=\"clipup\",\n",
     "    optimizer_config={\"max_speed\": MAX_SPEED},\n",
     "    stdev_learning_rate=0.1,\n",
+    "    distributed=distributed_algorithm,\n",
     ")\n",
     "\n",
     "searcher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef3ad66e-e11c-4fa4-b250-e6786ce94270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "task_name_for_saving = TASK_NAME.split(\"::\")[-1]\n",
+    "now_as_str = datetime.now().strftime(\"%Y-%m-%d-%H.%M.%S\")\n",
+    "OUTPUT_DIR = f\"{task_name_for_saving}_{now_as_str}_{os.getpid()}\"\n",
+    "\n",
+    "print(\"PicklingLogger will save into\", OUTPUT_DIR)"
    ]
   },
   {
@@ -274,7 +363,7 @@
    "outputs": [],
    "source": [
     "_ = StdOutLogger(searcher)\n",
-    "pickler = PicklingLogger(searcher, interval=5, directory=\"humanoid_results\")"
+    "pickler = PicklingLogger(searcher, interval=SAVE_INTERVAL, directory=OUTPUT_DIR)"
    ]
   },
   {
@@ -292,7 +381,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "searcher.run(100)"
+    "for generation in range(1, 1 + NUM_GENERATIONS):\n",
+    "    t_before_step = datetime.now()\n",
+    "    searcher.step()\n",
+    "    t_after_step = datetime.now()\n",
+    "    print(\"Elapsed:\", (t_after_step - t_before_step).total_seconds())"
    ]
   },
   {
@@ -308,234 +401,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5731e007-55b3-49ef-9285-9d9137232c9d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pickler.unpickle_last_file()"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "0efa9df1-c978-4c2a-a528-c98e761caec7",
+   "id": "1951f337-91ed-40a3-b432-600c8380c286",
    "metadata": {},
    "source": [
-    "Now, we receive our trained policy as a torch module."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ea4d211-08c2-4a59-ab84-23988646895e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "center_solution = searcher.status[\"center\"]\n",
-    "policy = problem.to_policy(center_solution)\n",
-    "policy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e7c7581d-24ba-4f06-88e2-41bb3274cd37",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "# Visualizing the trained policy\n",
-    "\n",
-    "Now that we have our final policy, we manually run and visualize it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c99f0ea4-7638-4e8a-a0a2-d9f483c8c096",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import jax\n",
-    "\n",
-    "import brax\n",
-    "\n",
-    "if ENV_NAME.startswith(\"brax::old::\"):\n",
-    "    import brax.v1\n",
-    "    import brax.v1.envs\n",
-    "    import brax.v1.jumpy as jp\n",
-    "    from brax.v1.io import html\n",
-    "    from brax.v1.io import image\n",
-    "else:\n",
-    "    try:\n",
-    "        import jumpy as jp\n",
-    "    except ImportError:\n",
-    "        import brax.jumpy as jp\n",
-    "    import brax.envs\n",
-    "    from brax.io import html\n",
-    "    from brax.io import image\n",
-    "\n",
-    "from IPython.display import HTML, Image\n",
-    "\n",
-    "import numpy as np\n",
-    "\n",
-    "from typing import Iterable, Optional\n",
-    "\n",
-    "import random"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19d38fe1-9d6f-40ec-926d-3c4066a4b66a",
-   "metadata": {},
-   "source": [
-    "Below, we define a utility function named `use_policy(...)`.\n",
-    "\n",
-    "The expected arguments of `use_policy(...)` are as follows:\n",
-    "\n",
-    "- `torch_module`: The policy object, expected as a `nn.Module` instance.\n",
-    "- `x`: The observation, as an iterable of real numbers.\n",
-    "- `h`: The hidden state of the module, if such a state exists and if the module is recurrent. Otherwise, it can be left as None.\n",
-    "\n",
-    "The return values of this function are as follows:\n",
-    "\n",
-    "- The action recommended by the policy, as a numpy array\n",
-    "- The hidden state of the module, if the module is a recurrent one."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e8c6554d-4bdb-49b9-8c2e-956bce6ddb8a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@torch.no_grad()\n",
-    "def use_policy(torch_module: nn.Module, x: Iterable, h: Optional[Iterable] = None) -> tuple:\n",
-    "    x = torch.as_tensor(np.array(x), dtype=torch.float32)\n",
-    "    if h is None:\n",
-    "        result = torch_module(x)\n",
-    "    else:\n",
-    "        result = torch_module(x, h)\n",
-    "\n",
-    "    if isinstance(result, tuple):\n",
-    "        x, h = result\n",
-    "        x = x.numpy()\n",
-    "    else:\n",
-    "        x = result.numpy()\n",
-    "        h = None\n",
-    "        \n",
-    "    return x, h"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "28c044fe-4639-411c-be78-ac09cbe5e78f",
-   "metadata": {},
-   "source": [
-    "We now initialize a new instance of our brax environment, and trigger the jit compilation on its `reset` and `step` methods."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1251e82-1d0f-4e43-a6c5-1ec4c0275dab",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if ENV_NAME.startswith(\"brax::old::\"):\n",
-    "    env = brax.v1.envs.create(env_name=ENV_NAME[11:])\n",
-    "else:\n",
-    "    env = brax.envs.create(env_name=ENV_NAME[6:])\n",
-    "\n",
-    "reset = jax.jit(env.reset)\n",
-    "step = jax.jit(env.step)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55229cc2-aad5-4c78-b095-010a538adb40",
-   "metadata": {},
-   "source": [
-    "Below we run our policy and collect the states of the episodes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "220ec837-1d1a-401e-a144-5516bdb3e493",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "seed = random.randint(0, (2 ** 32) - 1)\n",
-    "\n",
-    "if hasattr(jp, \"random_prngkey\"):\n",
-    "    state = reset(rng=jp.random_prngkey(seed=seed))\n",
-    "else:\n",
-    "    state = reset(rng=jax.random.PRNGKey(seed=seed))\n",
-    "\n",
-    "h = None\n",
-    "states = []\n",
-    "cumulative_reward = 0.0\n",
-    "\n",
-    "while True:\n",
-    "    action, h = use_policy(policy, state.obs, h)\n",
-    "    state = step(state, action)\n",
-    "    cumulative_reward += float(state.reward)\n",
-    "    states.append(state)\n",
-    "    if np.abs(np.array(state.done)) > 1e-4:\n",
-    "        break"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c9bbe53a-40f5-4bf5-a063-47f1d88032d6",
-   "metadata": {},
-   "source": [
-    "Length of the episode and the total reward:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "80345e9c-0694-413d-81c2-205dfacdfb5a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(states), cumulative_reward"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b6ec424-e6cc-453a-93fd-eb07e44c1bd6",
-   "metadata": {},
-   "source": [
-    "Visualization of the policy:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7ec60419-1ad0-4f19-bc1e-f2048577ea29",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if ENV_NAME.startswith(\"brax::old::\"):\n",
-    "    env_sys = env.sys\n",
-    "    states_to_render = [state.qp for state in states]\n",
-    "else:\n",
-    "    env_sys = env.sys.replace(dt=env.dt)\n",
-    "    states_to_render = [state.pipeline_state for state in states]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a07c70f6-2c93-43a1-b4c3-edd3f395302a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "HTML(html.render(env_sys, states_to_render))"
+    "See the notebook [Brax_Experiments_Visualization.ipynb](Brax_Experiments_Visualization.ipynb) for visualizing the pickle files generated by this notebook."
    ]
   }
  ],
@@ -555,7 +425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/evotorch/neuroevolution/net/vecrl.py
+++ b/src/evotorch/neuroevolution/net/vecrl.py
@@ -1623,7 +1623,7 @@ class SyncVectorEnv(BaseVectorEnv):
                 if env.observation_space.shape != single_observation_space.shape:
                     raise ValueError("The observation shapes of the sub-environments do not match")
                 if isinstance(env.action_space, Discrete):
-                    if not isinstance(single_action_space.Discrete):
+                    if not isinstance(single_action_space, Discrete):
                         raise TypeError("The action space types of the sub-environments do not match")
                     if env.action_space.n != single_action_space.n:
                         raise ValueError("The discrete numbers of actions of the sub-environments do not match")


### PR DESCRIPTION
This pull request updates vectorized reinforcement functionalities of EvoTorch, so that they are compatible with the [gymnasium 1.0.x API](https://github.com/Farama-Foundation/Gymnasium/releases/tag/v1.0.0a1) (while preserving compatibility with gymnasium 0.29.x).

In more details, this pull request introduces an EvoTorch-specific `SyncVectorEnv` implementation (as an alternative to gymnasium's `SyncVectorEnv` class). This custom SyncVectorEnv preserves the classical auto-reset behavior on which EvoTorch relies, allowing us to transition to gymnasium 1.0.x.

Having our custom `SyncVectorEnv` allows us to introduce these performance-related improvements as well:

- observations, rewards, etc. reported by `SyncVectorEnv` are now moved into the device of where the policies are executed;
- sub-environments of SyncVectorEnv that have reached the maximum number of episodes are not executed further.

[Brax](https://github.com/google/brax)-related notebook examples are also refactored. Instead of including the entire brax example in a single notebook, there are now two notebooks, one focusing on the training and the other focusing on the visualization. The visualization example is updated so that it works correctly with the latest version of brax.