### PR TITLE
Fix VecGymNE so that it can work with adaptive popsize

### DIFF
--- a/src/evotorch/neuroevolution/vecgymne.py
+++ b/src/evotorch/neuroevolution/vecgymne.py
@@ -435,6 +435,8 @@ class VecGymNE(BaseNEProblem):
             subbatch_size=subbatch_size,
         )
 
+        self.after_eval_hook.append(self._extra_status)
+
     def _parallelize(self):
         super()._parallelize()
         if self.is_main:
@@ -451,6 +453,9 @@ class VecGymNE(BaseNEProblem):
     def _set_actor_max_num_envs(self, n: int):
         self._actor_max_num_envs = n
         self._actor_max_num_envs_ready = True
+
+    def _extra_status(self, batch: SolutionBatch):
+        return dict(total_interaction_count=self.interaction_count, total_episode_count=self.episode_count)
 
     @property
     def observation_normalization(self) -> bool:


### PR DESCRIPTION
The problem class `VecGymNE` used to fail when a distribution-based search algorithm (such as `PGPE` or `CEM`) was used with adaptive population size (enabled with the setting `num_interactions=...`) in non-distributed mode (i.e. with `distributed` set as False). The reason for this was that `VecGymNE` was not reporting the number interactions and the number of episodes it encountered in its status dictionary. This pull request fixes this mentioned issue, allowing `VecGymNE` to work with adaptive population size under non-distributed mode.