### PR TITLE
Fix the "center" of CMAES to be 1-dimensional

### DIFF
--- a/src/evotorch/algorithms/cmaes.py
+++ b/src/evotorch/algorithms/cmaes.py
@@ -251,7 +251,13 @@ class CMAES(SearchAlgorithm, SinglePopulationAlgorithmMixin):
             center_init = center_init.values.clone()
 
         # Store the center
-        self.m = self._problem.make_tensor(center_init)
+        self.m = self._problem.make_tensor(center_init).squeeze()
+        valid_shaped_m = (self.m.ndim == 1) and (len(self.m) == self._problem.solution_length)
+        if not valid_shaped_m:
+            raise ValueError(
+                f"The initial center point was expected as a vector of length {self._problem.solution_length}."
+                " However, the provided `center_init` has (or implies) a different shape."
+            )
 
         # Store the initial step size
         self.sigma = self._problem.make_tensor(stdev_init)


### PR DESCRIPTION
Addressed issue:
https://github.com/nnaisense/evotorch/issues/110

During the initialization of CMAES, the center point of the search was generated not as a vector of length `n`, but as a tensor of shape `(1, n)`. Because of this, the reported "center" solution in the status dictionary also ended up with an unexpected leftmost dimension with size 1.

This fix introduces a `squeeze()` operation on the initial center tensor, and also a shape verification, ensuring that the center tensor is 1-dimensional and has a correct length. With these changes, the reported "center" in the status dictionary becomes 1-dimensional.